### PR TITLE
feat: scroll long command descriptions in command palette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ benchmarks/results-*.json
 # OpenCode local settings
 .opencode/
 
+# Local git worktrees
+.worktrees/
+
 # Installed agent skills (user-specific)
 .agents/
 

--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -180,7 +180,33 @@ function HeaderRow({
   );
 }
 
-function CommandRow({
+interface CommandRowProps {
+  def: CommandDef;
+  isActive: boolean;
+  catColor: string;
+  innerW: number;
+  matchIndices: number[] | undefined;
+  textSecondary: string;
+  textMuted: string;
+  textFaint: string;
+  textPrimary: string;
+}
+
+function getDescMaxWidth(innerW: number, cmdText: string): number {
+  return Math.max(0, innerW - cmdText.length - 14);
+}
+
+function truncateDesc(desc: string, descMaxWidth: number): string {
+  if (descMaxWidth <= 0) {
+    return "";
+  }
+  if (desc.length > descMaxWidth) {
+    return `${desc.slice(0, descMaxWidth - 1)}…`;
+  }
+  return desc;
+}
+
+function RowLayout({
   def,
   isActive,
   catColor,
@@ -190,6 +216,7 @@ function CommandRow({
   textMuted,
   textFaint,
   textPrimary,
+  displayDesc,
 }: {
   def: CommandDef;
   isActive: boolean;
@@ -200,14 +227,12 @@ function CommandRow({
   textMuted: string;
   textFaint: string;
   textPrimary: string;
+  displayDesc: string;
 }) {
   const bg = isActive ? POPUP_HL : POPUP_BG;
   const cmdColor = isActive ? catColor : textSecondary;
   const descColor = isActive ? textSecondary : textMuted;
   const cmdText = def.cmd;
-
-  const descMaxWidth = Math.max(0, innerW - cmdText.length - 14);
-  const displayDesc = useMarqueeScroll(def.desc, descMaxWidth, isActive);
 
   return (
     <PopupRow bg={bg} w={innerW}>
@@ -231,6 +256,27 @@ function CommandRow({
       </text>
     </PopupRow>
   );
+}
+
+function ActiveCommandRow(props: CommandRowProps) {
+  const descMaxWidth = getDescMaxWidth(props.innerW, props.def.cmd);
+  const displayDesc = useMarqueeScroll(props.def.desc, descMaxWidth, true);
+
+  return <RowLayout {...props} displayDesc={displayDesc} />;
+}
+
+function InactiveCommandRow(props: CommandRowProps) {
+  const descMaxWidth = getDescMaxWidth(props.innerW, props.def.cmd);
+  const displayDesc = truncateDesc(props.def.desc, descMaxWidth);
+
+  return <RowLayout {...props} displayDesc={displayDesc} />;
+}
+
+function CommandRow(props: CommandRowProps) {
+  if (props.isActive) {
+    return <ActiveCommandRow {...props} />;
+  }
+  return <InactiveCommandRow {...props} />;
 }
 
 interface Props {

--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -206,7 +206,7 @@ function CommandRow({
   const descColor = isActive ? textSecondary : textMuted;
   const cmdText = def.cmd;
 
-  const descMaxWidth = Math.max(0, innerW - cmdText.length - 12);
+  const descMaxWidth = Math.max(0, innerW - cmdText.length - 14);
   const displayDesc = useMarqueeScroll(def.desc, descMaxWidth, isActive);
 
   return (

--- a/src/components/modals/CommandPalette.tsx
+++ b/src/components/modals/CommandPalette.tsx
@@ -5,6 +5,7 @@ import { CATEGORIES, type CommandDef, getCommandDefs } from "../../core/commands
 import { fuzzyMatch } from "../../core/history/fuzzy.js";
 import { icon } from "../../core/icons.js";
 import { useTheme } from "../../core/theme/index.js";
+import { useMarqueeScroll } from "../../hooks/useMarqueeScroll.js";
 import { usePopupScroll } from "../../hooks/usePopupScroll.js";
 import { POPUP_BG, POPUP_HL, Popup, PopupRow, PopupSeparator } from "../layout/shared.js";
 
@@ -205,6 +206,9 @@ function CommandRow({
   const descColor = isActive ? textSecondary : textMuted;
   const cmdText = def.cmd;
 
+  const descMaxWidth = Math.max(0, innerW - cmdText.length - 12);
+  const displayDesc = useMarqueeScroll(def.desc, descMaxWidth, isActive);
+
   return (
     <PopupRow bg={bg} w={innerW}>
       <text fg={isActive ? catColor : textFaint} bg={bg}>
@@ -223,9 +227,7 @@ function CommandRow({
       )}
       <text fg={descColor} bg={bg} truncate>
         {"  "}
-        {def.desc.length > innerW - cmdText.length - 12
-          ? `${def.desc.slice(0, innerW - cmdText.length - 15)}…`
-          : def.desc}
+        {displayDesc}
       </text>
     </PopupRow>
   );

--- a/src/hooks/useMarqueeScroll.ts
+++ b/src/hooks/useMarqueeScroll.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from "react";
+
+const SCROLL_INTERVAL = 100;
+const PAUSE_TICKS = 10;
+
+export function useMarqueeScroll(text: string, maxWidth: number, active: boolean): string {
+  const [scrollPos, setScrollPos] = useState(0);
+  const pauseRef = useRef(PAUSE_TICKS);
+
+  useEffect(() => {
+    if (!active || maxWidth <= 0 || text.length <= maxWidth) {
+      setScrollPos(0);
+      return;
+    }
+
+    pauseRef.current = PAUSE_TICKS;
+    const maxPos = text.length - maxWidth;
+    let endPause = 0;
+
+    const timer = setInterval(() => {
+      if (endPause > 0) {
+        endPause--;
+        if (endPause === 0) setScrollPos(0);
+        return;
+      }
+      setScrollPos((prev) => {
+        if (prev === 0 && pauseRef.current > 0) {
+          pauseRef.current--;
+          return 0;
+        }
+        if (prev >= maxPos) {
+          pauseRef.current = PAUSE_TICKS;
+          endPause = PAUSE_TICKS;
+          return prev;
+        }
+        return prev + 1;
+      });
+    }, SCROLL_INTERVAL);
+
+    return () => clearInterval(timer);
+  }, [active, text.length, maxWidth]);
+
+  if (active && maxWidth > 0 && text.length > maxWidth) {
+    return text.slice(scrollPos, scrollPos + maxWidth);
+  }
+  if (maxWidth > 0 && text.length > maxWidth) {
+    return `${text.slice(0, maxWidth - 1)}…`;
+  }
+  return text;
+}

--- a/src/hooks/useMarqueeScroll.ts
+++ b/src/hooks/useMarqueeScroll.ts
@@ -8,7 +8,11 @@ export function useMarqueeScroll(text: string, maxWidth: number, active: boolean
   const pauseRef = useRef(PAUSE_TICKS);
 
   useEffect(() => {
-    if (!active || maxWidth <= 0 || text.length <= maxWidth) {
+    if (maxWidth <= 0) {
+      setScrollPos(0);
+      return;
+    }
+    if (!active || text.length <= maxWidth) {
       setScrollPos(0);
       return;
     }
@@ -40,10 +44,13 @@ export function useMarqueeScroll(text: string, maxWidth: number, active: boolean
     return () => clearInterval(timer);
   }, [active, text.length, maxWidth]);
 
-  if (active && maxWidth > 0 && text.length > maxWidth) {
+  if (maxWidth <= 0) {
+    return "";
+  }
+  if (active && text.length > maxWidth) {
     return text.slice(scrollPos, scrollPos + maxWidth);
   }
-  if (maxWidth > 0 && text.length > maxWidth) {
+  if (text.length > maxWidth) {
     return `${text.slice(0, maxWidth - 1)}…`;
   }
   return text;

--- a/src/hooks/useMarqueeScroll.ts
+++ b/src/hooks/useMarqueeScroll.ts
@@ -3,47 +3,51 @@ import { useEffect, useRef, useState } from "react";
 const SCROLL_INTERVAL = 100;
 const PAUSE_TICKS = 10;
 
-export function useMarqueeScroll(text: string, maxWidth: number, active: boolean): string {
-  const [scrollPos, setScrollPos] = useState(0);
-  const pauseRef = useRef(PAUSE_TICKS);
+export interface MarqueeState {
+  scrollPos: number;
+  startPause: number;
+  endPause: number;
+}
 
-  useEffect(() => {
-    if (maxWidth <= 0) {
-      setScrollPos(0);
-      return;
-    }
-    if (!active || text.length <= maxWidth) {
-      setScrollPos(0);
-      return;
-    }
+export function tickMarquee(state: MarqueeState, maxPos: number, pauseTicks: number): MarqueeState {
+  if (state.endPause > 0) {
+    const nextEndPause = state.endPause - 1;
+    return {
+      scrollPos: nextEndPause === 0 ? 0 : state.scrollPos,
+      startPause: state.startPause,
+      endPause: nextEndPause,
+    };
+  }
 
-    pauseRef.current = PAUSE_TICKS;
-    const maxPos = text.length - maxWidth;
-    let endPause = 0;
+  if (state.scrollPos === 0 && state.startPause > 0) {
+    return {
+      scrollPos: 0,
+      startPause: state.startPause - 1,
+      endPause: 0,
+    };
+  }
 
-    const timer = setInterval(() => {
-      if (endPause > 0) {
-        endPause--;
-        if (endPause === 0) setScrollPos(0);
-        return;
-      }
-      setScrollPos((prev) => {
-        if (prev === 0 && pauseRef.current > 0) {
-          pauseRef.current--;
-          return 0;
-        }
-        if (prev >= maxPos) {
-          pauseRef.current = PAUSE_TICKS;
-          endPause = PAUSE_TICKS;
-          return prev;
-        }
-        return prev + 1;
-      });
-    }, SCROLL_INTERVAL);
+  if (state.scrollPos >= maxPos) {
+    return {
+      scrollPos: state.scrollPos,
+      startPause: pauseTicks,
+      endPause: pauseTicks,
+    };
+  }
 
-    return () => clearInterval(timer);
-  }, [active, text.length, maxWidth]);
+  return {
+    scrollPos: state.scrollPos + 1,
+    startPause: state.startPause,
+    endPause: state.endPause,
+  };
+}
 
+export function getMarqueeDisplayText(
+  text: string,
+  maxWidth: number,
+  active: boolean,
+  scrollPos: number,
+): string {
   if (maxWidth <= 0) {
     return "";
   }
@@ -54,4 +58,35 @@ export function useMarqueeScroll(text: string, maxWidth: number, active: boolean
     return `${text.slice(0, maxWidth - 1)}…`;
   }
   return text;
+}
+
+export function useMarqueeScroll(text: string, maxWidth: number, active: boolean): string {
+  const [scrollPos, setScrollPos] = useState(0);
+  const stateRef = useRef<MarqueeState>({ scrollPos: 0, startPause: PAUSE_TICKS, endPause: 0 });
+
+  useEffect(() => {
+    if (maxWidth <= 0) {
+      stateRef.current = { scrollPos: 0, startPause: PAUSE_TICKS, endPause: 0 };
+      setScrollPos(0);
+      return;
+    }
+    if (!active || text.length <= maxWidth) {
+      stateRef.current = { scrollPos: 0, startPause: PAUSE_TICKS, endPause: 0 };
+      setScrollPos(0);
+      return;
+    }
+
+    stateRef.current = { scrollPos: 0, startPause: PAUSE_TICKS, endPause: 0 };
+    const maxPos = text.length - maxWidth;
+
+    const timer = setInterval(() => {
+      const next = tickMarquee(stateRef.current, maxPos, PAUSE_TICKS);
+      stateRef.current = next;
+      setScrollPos(next.scrollPos);
+    }, SCROLL_INTERVAL);
+
+    return () => clearInterval(timer);
+  }, [active, text, maxWidth]);
+
+  return getMarqueeDisplayText(text, maxWidth, active, scrollPos);
 }

--- a/tests/useMarqueeScroll.test.ts
+++ b/tests/useMarqueeScroll.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { getMarqueeDisplayText, tickMarquee } from "../src/hooks/useMarqueeScroll.js";
+
+describe("tickMarquee", () => {
+  it("runs start pause, scrolls, pauses at end, then resets", () => {
+    const maxPos = 3;
+    const pauseTicks = 2;
+    let state = { scrollPos: 0, startPause: pauseTicks, endPause: 0 };
+
+    state = tickMarquee(state, maxPos, pauseTicks);
+    expect(state).toEqual({ scrollPos: 0, startPause: 1, endPause: 0 });
+
+    state = tickMarquee(state, maxPos, pauseTicks);
+    expect(state).toEqual({ scrollPos: 0, startPause: 0, endPause: 0 });
+
+    state = tickMarquee(state, maxPos, pauseTicks);
+    expect(state).toEqual({ scrollPos: 1, startPause: 0, endPause: 0 });
+
+    state = tickMarquee(state, maxPos, pauseTicks);
+    expect(state).toEqual({ scrollPos: 2, startPause: 0, endPause: 0 });
+
+    state = tickMarquee(state, maxPos, pauseTicks);
+    expect(state).toEqual({ scrollPos: 3, startPause: 0, endPause: 0 });
+
+    state = tickMarquee(state, maxPos, pauseTicks);
+    expect(state).toEqual({ scrollPos: 3, startPause: 2, endPause: 2 });
+
+    state = tickMarquee(state, maxPos, pauseTicks);
+    expect(state).toEqual({ scrollPos: 3, startPause: 2, endPause: 1 });
+
+    state = tickMarquee(state, maxPos, pauseTicks);
+    expect(state).toEqual({ scrollPos: 0, startPause: 2, endPause: 0 });
+  });
+
+  it("increments position while in normal scrolling range", () => {
+    const next = tickMarquee({ scrollPos: 4, startPause: 0, endPause: 0 }, 6, 10);
+    expect(next).toEqual({ scrollPos: 5, startPause: 0, endPause: 0 });
+  });
+});
+
+describe("getMarqueeDisplayText", () => {
+  it("returns empty when max width is zero or less", () => {
+    expect(getMarqueeDisplayText("abcdef", 0, false, 0)).toBe("");
+    expect(getMarqueeDisplayText("abcdef", -1, true, 3)).toBe("");
+  });
+
+  it("returns active marquee window and inactive truncated text", () => {
+    expect(getMarqueeDisplayText("abcdef", 4, true, 1)).toBe("bcde");
+    expect(getMarqueeDisplayText("abcdef", 4, false, 0)).toBe("abc…");
+  });
+});


### PR DESCRIPTION
Summary
- add marquee scrolling for long command descriptions in the command palette
- start scrolling after a 1s pause and hold for 1s at the end before resetting
- keep inactive rows truncated, as before
- extract the scroll behavior into useMarqueeScroll to match the existing hooks structure

Verification
- bun run lint:fix
- bun run format
- bun run typecheck