### PR TITLE
Fix blank assistant messages being marked complete

### DIFF
--- a/src/hooks/useChat-content.ts
+++ b/src/hooks/useChat-content.ts
@@ -1,0 +1,60 @@
+import type { ChatMessage, MessageSegment, ToolCall } from "../types/index.js";
+
+interface RenderableAssistantContentOptions {
+  fullText: string;
+  toolCallCount: number;
+  segments: MessageSegment[];
+}
+
+export function hasRenderableAssistantContent({
+  fullText,
+  toolCallCount,
+  segments,
+}: RenderableAssistantContentOptions): boolean {
+  if (fullText.trim().length > 0) return true;
+  if (toolCallCount > 0) return true;
+
+  for (const segment of segments) {
+    if (segment.type === "plan") return true;
+    if (segment.type === "reasoning") return true;
+    if (segment.type === "text" && segment.content.trim().length > 0) return true;
+  }
+
+  return false;
+}
+
+interface BuildAssistantMessageOptions {
+  fullText: string;
+  completedCalls: ToolCall[];
+  segments: MessageSegment[];
+  responseStartedAt: number;
+  now: number;
+}
+
+export function buildAssistantMessage({
+  fullText,
+  completedCalls,
+  segments,
+  responseStartedAt,
+  now,
+}: BuildAssistantMessageOptions): ChatMessage | null {
+  if (
+    !hasRenderableAssistantContent({
+      fullText,
+      toolCallCount: completedCalls.length,
+      segments,
+    })
+  ) {
+    return null;
+  }
+
+  return {
+    id: crypto.randomUUID(),
+    role: "assistant",
+    content: fullText,
+    timestamp: now,
+    toolCalls: completedCalls.length > 0 ? completedCalls : undefined,
+    segments: segments.length > 0 ? segments : undefined,
+    durationMs: now - responseStartedAt,
+  };
+}

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -76,6 +76,7 @@ import type {
   QueuedMessage,
 } from "../types/index.js";
 import { reprimeContextFromMessages, safeParseArgs } from "./chat/message-processing.js";
+import { buildAssistantMessage, hasRenderableAssistantContent } from "./useChat-content.js";
 import { cycleForgeMode } from "./useForgeMode.js";
 import { buildSessionMeta } from "./useSessionBuilder.js";
 
@@ -1755,7 +1756,11 @@ export function useChat({
                   : {}),
             }));
           const allCalls = [...completedCalls, ...livePending];
-          const hasContent = fullText.trim().length > 0 || allCalls.length > 0;
+          const hasContent = hasRenderableAssistantContent({
+            fullText,
+            toolCallCount: allCalls.length,
+            segments: finalSegments,
+          });
 
           if (!hasContent) {
             setMessages((prev) => [...prev, ...steeringMsgs]);
@@ -2747,19 +2752,13 @@ export function useChat({
           syncV2Slots();
         }
 
-        const hasAssistantContent =
-          fullText.trim().length > 0 || completedCalls.length > 0 || finalSegments.length > 0;
-        const assistantMsg: ChatMessage | null = hasAssistantContent
-          ? {
-              id: crypto.randomUUID(),
-              role: "assistant",
-              content: fullText,
-              timestamp: Date.now(),
-              toolCalls: completedCalls.length > 0 ? completedCalls : undefined,
-              segments: finalSegments.length > 0 ? finalSegments : undefined,
-              durationMs: Date.now() - responseStartedAt,
-            }
-          : null;
+        const assistantMsg = buildAssistantMessage({
+          fullText,
+          completedCalls,
+          segments: finalSegments,
+          responseStartedAt,
+          now: Date.now(),
+        });
 
         const errorMsgs: ChatMessage[] = streamErrors.map((errContent) => ({
           id: crypto.randomUUID(),
@@ -2860,14 +2859,14 @@ export function useChat({
           }
           // Commit any partial assistant output so the retry has context
           if (fullText.trim().length > 0 || completedCalls.length > 0) {
-            const partialMsg: ChatMessage = {
-              id: crypto.randomUUID(),
-              role: "assistant",
-              content: fullText,
-              timestamp: Date.now(),
-              toolCalls: completedCalls.length > 0 ? completedCalls : undefined,
-              segments: finalSegments.length > 0 ? finalSegments : undefined,
-            };
+            const partialMsg = buildAssistantMessage({
+              fullText,
+              completedCalls,
+              segments: finalSegments,
+              responseStartedAt,
+              now: Date.now(),
+            });
+            if (!partialMsg) return;
             setMessages((prev) => [...prev, partialMsg]);
             if (completedCalls.length > 0) {
               const assistantContent: Array<TextPart | ToolCallPart> = [];
@@ -2981,15 +2980,22 @@ export function useChat({
         }
 
         const hasPlanPostAction = !!planPostActionRef.current;
-        if (!hasPlanPostAction && (fullText.trim().length > 0 || completedCalls.length > 0)) {
-          const partialMsg: ChatMessage = {
-            id: crypto.randomUUID(),
-            role: "assistant",
-            content: fullText,
-            timestamp: Date.now(),
-            toolCalls: completedCalls.length > 0 ? completedCalls : undefined,
-            segments: finalSegments.length > 0 ? finalSegments : undefined,
-          };
+        if (
+          !hasPlanPostAction &&
+          hasRenderableAssistantContent({
+            fullText,
+            toolCallCount: completedCalls.length,
+            segments: finalSegments,
+          })
+        ) {
+          const partialMsg = buildAssistantMessage({
+            fullText,
+            completedCalls,
+            segments: finalSegments,
+            responseStartedAt,
+            now: Date.now(),
+          });
+          if (!partialMsg) return;
           setMessages((prev) => [...prev, partialMsg]);
 
           if (completedCalls.length > 0) {

--- a/tests/usechat-content.test.ts
+++ b/tests/usechat-content.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildAssistantMessage,
+	hasRenderableAssistantContent,
+} from "../src/hooks/useChat-content.js";
+
+describe("hasRenderableAssistantContent", () => {
+	test("does not treat an orphan tools segment as visible assistant output", () => {
+		expect(
+			hasRenderableAssistantContent({
+				fullText: "",
+				toolCallCount: 0,
+				segments: [{ type: "tools", toolCallIds: ["call-1"] }],
+			}),
+		).toBe(false);
+	});
+
+	test("treats plan segments as visible assistant output", () => {
+		expect(
+			hasRenderableAssistantContent({
+				fullText: "",
+				toolCallCount: 0,
+				segments: [
+					{
+						type: "plan",
+						plan: {
+							title: "Set up files",
+							createdAt: Date.now(),
+							status: "active",
+							steps: [
+								{ id: "1", label: "Create config", status: "pending" },
+							],
+						},
+					},
+				],
+			}),
+		).toBe(true);
+	});
+
+	test("does not build a blank assistant message for orphan tool segments", () => {
+		expect(
+			buildAssistantMessage({
+				fullText: "",
+				completedCalls: [],
+				segments: [{ type: "tools", toolCallIds: ["call-1"] }],
+				responseStartedAt: 1_000,
+				now: 2_000,
+			}),
+		).toBeNull();
+	});
+
+	test("builds an assistant message for visible plan output", () => {
+		const message = buildAssistantMessage({
+			fullText: "",
+			completedCalls: [],
+			segments: [
+				{
+					type: "plan",
+					plan: {
+						title: "Set up files",
+						createdAt: 123,
+						status: "active",
+						steps: [{ id: "1", label: "Create config", status: "pending" }],
+					},
+				},
+			],
+			responseStartedAt: 1_000,
+			now: 2_500,
+		});
+
+		expect(message).toMatchObject({
+			role: "assistant",
+			content: "",
+			durationMs: 1_500,
+			segments: [
+				{
+					type: "plan",
+				},
+			],
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- stop finalizing assistant messages when the only collected output is a non-renderable segment
- extract shared assistant-content and assistant-message helpers so the final completion and partial-save paths use the same rules
- add regression tests that prove blank orphan tool segments do not create a completed assistant message

Closes #26.

## Testing
- `bun test tests/usechat-content.test.ts tests/codex-provider.test.ts tests/provider-status.test.ts`
- `bun run typecheck`
- `bunx @biomejs/biome check src/hooks/useChat.ts src/hooks/useChat-content.ts tests/usechat-content.test.ts`
- manually validated against the original issue scenario