### PR TITLE
fix: speed up model selector modal open path

### DIFF
--- a/src/components/modals/LlmSelector.tsx
+++ b/src/components/modals/LlmSelector.tsx
@@ -206,9 +206,15 @@ export function LlmSelector({ visible, activeModel, onSelect, onClose }: Props) 
   const [scrollOff, setScrollOff] = useState(0);
   const spinFrameRef = useSpinnerFrameRef();
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
-  // Defer the heavy entry list by one frame so the popup chrome paints instantly
+  // Tracks whether we've shown the loading spinner or deferred rendering.
+  // Set to true immediately when data is cached; deferred by one frame when loading.
   const [ready, setReady] = useState(false);
+  const anyLoadingRef = useRef(anyLoading);
+  anyLoadingRef.current = anyLoading;
 
+  // Reset state and initialize collapse when the modal opens.
+  // Only depends on [visible, activeModel] — anyLoading changes must NOT
+  // reset user state (query, cursor) while the modal is open.
   useEffect(() => {
     if (!visible) {
       setReady(false);
@@ -223,9 +229,14 @@ export function LlmSelector({ visible, activeModel, onSelect, onClose }: Props) 
       init[cfg.id] = cfg.id !== activeProvider;
     }
     setCollapsed(init);
-    // Paint the popup chrome first, then mount the entry list next frame
-    const raf = setTimeout(() => setReady(true), 0);
-    return () => clearTimeout(raf);
+    // When all data is cached, render immediately; otherwise defer one frame
+    if (!anyLoadingRef.current) {
+      setReady(true);
+    } else {
+      const raf = setTimeout(() => setReady(true), 0);
+      return () => clearTimeout(raf);
+    }
+    return undefined;
   }, [visible, activeModel]);
 
   const { providerFilter, modelFilter } = (() => {

--- a/src/components/modals/LlmSelector.tsx
+++ b/src/components/modals/LlmSelector.tsx
@@ -233,8 +233,8 @@ export function LlmSelector({ visible, activeModel, onSelect, onClose }: Props) 
     if (!anyLoadingRef.current) {
       setReady(true);
     } else {
-      const raf = setTimeout(() => setReady(true), 0);
-      return () => clearTimeout(raf);
+      const tid = setTimeout(() => setReady(true), 0);
+      return () => clearTimeout(tid);
     }
     return undefined;
   }, [visible, activeModel]);

--- a/src/hooks/useAllProviderModels.ts
+++ b/src/hooks/useAllProviderModels.ts
@@ -122,21 +122,24 @@ export function useAllProviderModels(active: boolean): UseAllProviderModelsRetur
       setAvailability(map);
     }
 
-    // If everything is cached, no need to fetch
-    if (!anyStale) return;
-
     let dead = false;
 
-    if (!cachedStatuses) {
-      // No boot-time cache — fetch fresh availability
-      checkProviders()
-        .then((statuses) => {
-          if (dead) return;
-          const map = new Map<string, boolean>();
-          for (const s of statuses) map.set(s.id, s.available);
-          setAvailability(map);
-        })
-        .catch(() => undefined);
+    // Refresh availability in the background even when cache exists.
+    // This keeps local providers (e.g. Ollama/LM Studio) from staying stale.
+    checkProviders()
+      .then((statuses) => {
+        if (dead) return;
+        const map = new Map<string, boolean>();
+        for (const s of statuses) map.set(s.id, s.available);
+        setAvailability(map);
+      })
+      .catch(() => undefined);
+
+    // If everything is cached, no need to fetch models
+    if (!anyStale) {
+      return () => {
+        dead = true;
+      };
     }
 
     // Only fetch providers that aren't cached yet

--- a/src/hooks/useAllProviderModels.ts
+++ b/src/hooks/useAllProviderModels.ts
@@ -105,17 +105,12 @@ export function useAllProviderModels(active: boolean): UseAllProviderModelsRetur
       for (const k of initKeys) {
         const a = prev[k];
         const b = init[k];
-        if (!a || a.loading !== b!.loading || a.items !== b!.items || a.error !== b!.error) {
+        if (!a || !b || a.loading !== b.loading || a.items !== b.items || a.error !== b.error) {
           return init;
         }
       }
       return prev;
     });
-
-    // If everything is cached, no need to fetch
-    if (!anyStale) return;
-
-    let dead = false;
 
     // Re-sync availability from the global cache (cheap map read).
     // If checkProviders() ran elsewhere (auth flow, config reload) the
@@ -125,7 +120,14 @@ export function useAllProviderModels(active: boolean): UseAllProviderModelsRetur
       const map = new Map<string, boolean>();
       for (const s of cachedStatuses) map.set(s.id, s.available);
       setAvailability(map);
-    } else {
+    }
+
+    // If everything is cached, no need to fetch
+    if (!anyStale) return;
+
+    let dead = false;
+
+    if (!cachedStatuses) {
       // No boot-time cache — fetch fresh availability
       checkProviders()
         .then((statuses) => {
@@ -134,7 +136,7 @@ export function useAllProviderModels(active: boolean): UseAllProviderModelsRetur
           for (const s of statuses) map.set(s.id, s.available);
           setAvailability(map);
         })
-        .catch(() => {});
+        .catch(() => undefined);
     }
 
     // Only fetch providers that aren't cached yet

--- a/src/hooks/useAllProviderModels.ts
+++ b/src/hooks/useAllProviderModels.ts
@@ -97,14 +97,17 @@ export function useAllProviderModels(active: boolean): UseAllProviderModelsRetur
 
     let dead = false;
 
-    checkProviders()
-      .then((statuses) => {
-        if (dead) return;
-        const map = new Map<string, boolean>();
-        for (const s of statuses) map.set(s.id, s.available);
-        setAvailability(map);
-      })
-      .catch(() => {});
+    // Only re-check provider availability if we don't have a boot-time cache
+    if (!getCachedProviderStatuses()) {
+      checkProviders()
+        .then((statuses) => {
+          if (dead) return;
+          const map = new Map<string, boolean>();
+          for (const s of statuses) map.set(s.id, s.available);
+          setAvailability(map);
+        })
+        .catch(() => {});
+    }
 
     // Only fetch providers that aren't cached yet
     for (const cfg of PROVIDER_CONFIGS) {

--- a/src/hooks/useAllProviderModels.ts
+++ b/src/hooks/useAllProviderModels.ts
@@ -90,7 +90,24 @@ export function useAllProviderModels(active: boolean): UseAllProviderModelsRetur
       }
       if (init[cfg.id]?.loading) anyStale = true;
     }
-    setProviderData(init);
+
+    // Only trigger a re-render if the fresh cache differs from current state.
+    // Checks loading/error flags (value comparison) and items (reference
+    // comparison — cache returns the same array object on re-read).
+    setProviderData((prev) => {
+      let changed = false;
+      for (const k of Object.keys(init)) {
+        const a = prev[k];
+        const b = init[k];
+        if (!a || a.loading !== b!.loading || a.items !== b!.items || a.error !== b!.error) {
+          changed = true;
+          break;
+        }
+      }
+      // Also detect new providers (dynamic registration via onProvidersChanged)
+      if (!changed && Object.keys(prev).length !== Object.keys(init).length) changed = true;
+      return changed ? init : prev;
+    });
 
     // If everything is cached, no need to fetch
     if (!anyStale) return;

--- a/src/hooks/useAllProviderModels.ts
+++ b/src/hooks/useAllProviderModels.ts
@@ -95,18 +95,21 @@ export function useAllProviderModels(active: boolean): UseAllProviderModelsRetur
     // Checks loading/error flags (value comparison) and items (reference
     // comparison — cache returns the same array object on re-read).
     setProviderData((prev) => {
-      let changed = false;
-      for (const k of Object.keys(init)) {
+      const initKeys = Object.keys(init);
+      const prevKeys = Object.keys(prev);
+      if (initKeys.length !== prevKeys.length) return init;
+      // Detect replaced keys: same length but different key set
+      for (const k of prevKeys) {
+        if (!(k in init)) return init;
+      }
+      for (const k of initKeys) {
         const a = prev[k];
         const b = init[k];
         if (!a || a.loading !== b!.loading || a.items !== b!.items || a.error !== b!.error) {
-          changed = true;
-          break;
+          return init;
         }
       }
-      // Also detect new providers (dynamic registration via onProvidersChanged)
-      if (!changed && Object.keys(prev).length !== Object.keys(init).length) changed = true;
-      return changed ? init : prev;
+      return prev;
     });
 
     // If everything is cached, no need to fetch
@@ -114,8 +117,16 @@ export function useAllProviderModels(active: boolean): UseAllProviderModelsRetur
 
     let dead = false;
 
-    // Only re-check provider availability if we don't have a boot-time cache
-    if (!getCachedProviderStatuses()) {
+    // Re-sync availability from the global cache (cheap map read).
+    // If checkProviders() ran elsewhere (auth flow, config reload) the
+    // global cache was updated but our local state wasn't.
+    const cachedStatuses = getCachedProviderStatuses();
+    if (cachedStatuses) {
+      const map = new Map<string, boolean>();
+      for (const s of cachedStatuses) map.set(s.id, s.available);
+      setAvailability(map);
+    } else {
+      // No boot-time cache — fetch fresh availability
       checkProviders()
         .then((statuses) => {
           if (dead) return;


### PR DESCRIPTION
## Summary
- avoid redundant provider/model state updates when cached data hasn't changed
- sync provider availability from cached statuses before stale-model early return to prevent stale selector availability
- keep initial model selector rendering immediate when cached data is ready and only defer when loading is active

