### PR TITLE
fix: prefer project instructions over global defaults

### DIFF
--- a/src/core/instructions.ts
+++ b/src/core/instructions.ts
@@ -11,7 +11,7 @@ interface InstructionSource {
 }
 
 // Unlike skills, global instruction files are user-authored personal steering.
-// Keep global content later in prompt so it overrides repo-local guidance on conflicts.
+// Keep project-local content later in prompt so repo guidance overrides global defaults on conflicts.
 export const INSTRUCTION_SOURCES: InstructionSource[] = [
   {
     id: "soulforge",
@@ -208,8 +208,16 @@ export function buildInstructionPrompt(instructions: LoadedInstruction[]): strin
 
   if (globalInstructions.length > 0) {
     parts.push(
-      "Global instruction files apply across all projects and take priority over project-local instruction files when they conflict.",
+      "Global instruction files apply across all projects, but project-local instruction files take priority when they conflict.",
     );
+  }
+
+  if (globalInstructions.length > 0) {
+    const globalParts: string[] = [];
+    for (const inst of globalInstructions) {
+      globalParts.push(`[global:${inst.file}]\n${inst.content}`);
+    }
+    parts.push(`Global instruction files:\n${globalParts.join("\n\n")}`);
   }
 
   if (projectInstructions.length > 0) {
@@ -226,14 +234,6 @@ export function buildInstructionPrompt(instructions: LoadedInstruction[]): strin
         ? `Project-local instruction files:\n${projectParts.join("\n\n")}`
         : projectParts.join("\n\n"),
     );
-  }
-
-  if (globalInstructions.length > 0) {
-    const globalParts: string[] = [];
-    for (const inst of globalInstructions) {
-      globalParts.push(`[global:${inst.file}]\n${inst.content}`);
-    }
-    parts.push(`Global instruction files:\n${globalParts.join("\n\n")}`);
   }
 
   return `Project instructions:\n${parts.join("\n\n")}`;

--- a/tests/instructions-loader.test.ts
+++ b/tests/instructions-loader.test.ts
@@ -92,7 +92,7 @@ describe("instruction loading", () => {
 
     expect(loaded.map((inst) => inst.scope)).toEqual(["project", "global"]);
     expect(prompt).toContain(
-      "Global instruction files apply across all projects and take priority over project-local instruction files when they conflict.",
+      "Global instruction files apply across all projects, but project-local instruction files take priority when they conflict.",
     );
     expect(prompt).toContain("Project-local instruction files:");
     expect(prompt).toContain("[project:AGENTS.md]");
@@ -102,7 +102,7 @@ describe("instruction loading", () => {
     expect(prompt.indexOf("Global instruction files apply across all projects")).toBeLessThan(
       prompt.indexOf("[project:AGENTS.md]"),
     );
-    expect(prompt.indexOf("global codex")).toBeGreaterThan(prompt.indexOf("project codex"));
+    expect(prompt.indexOf("project codex")).toBeGreaterThan(prompt.indexOf("global codex"));
   });
 
   it("keeps both scopes when project and global instructions share source", () => {
@@ -116,7 +116,7 @@ describe("instruction loading", () => {
     expect(loaded.map((inst) => inst.scope)).toEqual(["project", "global"]);
     expect(loaded.map((inst) => inst.content)).toEqual(["project soulforge", "global soulforge"]);
     expect(loaded.map((inst) => inst.file)).toEqual(["SOULFORGE.md", ".soulforge/SOULFORGE.md"]);
-    expect(prompt.indexOf("global soulforge")).toBeGreaterThan(prompt.indexOf("project soulforge"));
+    expect(prompt.indexOf("project soulforge")).toBeGreaterThan(prompt.indexOf("global soulforge"));
   });
 
   it("loads global instructions from homedir() by default in fresh process", () => {

--- a/tests/instructions-loader.test.ts
+++ b/tests/instructions-loader.test.ts
@@ -1,9 +1,39 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildInstructionPrompt, loadInstructions } from "../src/core/instructions.js";
 import { ContextManager } from "../src/core/context/manager.js";
+import { buildInstructionPrompt, loadInstructions } from "../src/core/instructions.js";
+
+const INSTRUCTIONS_MODULE_URL = new URL("../src/core/instructions.ts", import.meta.url).href;
+
+function loadInstructionsInFreshProcess(
+  projectDir: string,
+  homeDir: string,
+): ReturnType<typeof loadInstructions> {
+  const script = `
+    import { loadInstructions } from ${JSON.stringify(INSTRUCTIONS_MODULE_URL)};
+
+    const projectDir = process.env.PROJECT_DIR;
+    if (!projectDir) throw new Error("PROJECT_DIR missing");
+
+    const loaded = loadInstructions(projectDir, ["soulforge"]);
+    process.stdout.write(JSON.stringify(loaded));
+  `;
+
+  return JSON.parse(
+    execFileSync(process.execPath, ["-e", script], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: homeDir,
+        PROJECT_DIR: projectDir,
+        USERPROFILE: homeDir,
+      },
+    }),
+  ) as ReturnType<typeof loadInstructions>;
+}
 
 describe("instruction loading", () => {
   let rootDir: string;
@@ -89,35 +119,19 @@ describe("instruction loading", () => {
     expect(prompt.indexOf("global soulforge")).toBeGreaterThan(prompt.indexOf("project soulforge"));
   });
 
-  it("loads global instructions from homedir() by default", () => {
-    const actualHome = process.env.HOME ?? tmpdir();
-    const homeInstructionsDir = join(actualHome, ".soulforge");
-    const instructionsFile = join(homeInstructionsDir, "SOULFORGE.md");
-    let previousContent: string | null = null;
-    let hadPrevious = false;
+  it("loads global instructions from homedir() by default in fresh process", () => {
+    mkdirSync(join(homeDir, ".soulforge"), { recursive: true });
+    writeFileSync(join(homeDir, ".soulforge", "SOULFORGE.md"), "global soulforge");
 
-    try {
-      previousContent = Bun.file(instructionsFile).textSync();
-      hadPrevious = true;
-    } catch {}
+    const loaded = loadInstructionsInFreshProcess(projectDir, homeDir);
 
-    mkdirSync(homeInstructionsDir, { recursive: true });
-    writeFileSync(instructionsFile, "global soulforge");
-
-    try {
-      const loaded = loadInstructions(projectDir, ["soulforge"]);
-
-      expect(loaded).toHaveLength(1);
-      expect(loaded[0]).toMatchObject({
-        source: "soulforge",
-        file: ".soulforge/SOULFORGE.md",
-        scope: "global",
-        content: "global soulforge",
-      });
-    } finally {
-      if (!hadPrevious) rmSync(instructionsFile, { force: true });
-      else writeFileSync(instructionsFile, previousContent ?? "");
-    }
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toMatchObject({
+      source: "soulforge",
+      file: ".soulforge/SOULFORGE.md",
+      scope: "global",
+      content: "global soulforge",
+    });
   });
 
   it("dedupes project and global roots when they resolve to same directory", () => {


### PR DESCRIPTION
## Summary

Follow-up to #49.

After revisiting the instruction precedence from that PR, project-local instructions should take priority over global defaults. Global instructions are useful as personal defaults across all repos, but each project has its own conventions, tooling, and constraints. When those conflict, repo-specific guidance should be the final word.

This change keeps both global and project instruction files loaded, but renders global instructions first and project-local instructions after them in the assembled prompt. The prompt wording is also updated so the precedence is explicit.

This fix comes with updates to `tests/instructions-loader.test.ts`:

- verifies that project instructions override global ones by appearing later in the prompt
- keeps coverage for project and global instructions from the same source being loaded together
- isolates the HOME regression test by running the loader in a fresh Bun process with a temp home directory, instead of touching the real user home
