### PR TITLE
fix: add error logging to critical empty catch blocks

### DIFF
--- a/src/core/context/manager.ts
+++ b/src/core/context/manager.ts
@@ -254,7 +254,7 @@ export class ContextManager {
         const store = useRepoMapStore.getState();
         store.setSemanticStatus("generating");
         store.setSemanticProgress(`${String(count)} stale — regenerating...`);
-        this.generateSemanticSummaries(modelId).catch(() => {});
+        this.generateSemanticSummaries(modelId).catch((e) => { console.error("[context-manager] generateSemanticSummaries failed:", e instanceof Error ? e.message : String(e)); });
       } else {
         const stats = this.repoMap.getStatsCached();
         useRepoMapStore.getState().setSemanticCount(stats.summaries);
@@ -390,7 +390,7 @@ export class ContextManager {
             this.pendingSoulMapDiff = null;
           }
         })
-        .catch(() => {});
+        .catch((e) => { console.error("[context-manager] prefetchDiffBlock failed:", e instanceof Error ? e.message : String(e)); });
     }, 300);
   }
 
@@ -467,7 +467,9 @@ export class ContextManager {
       if (this.soulMapSnapshotPaths.size === 0) {
         this.soulMapSnapshotPaths = new Set(result.paths);
       }
-    } catch {}
+    } catch (e) {
+      console.error("[context-manager] warmRepoMapCache failed:", e instanceof Error ? e.message : String(e));
+    }
     this.repoMapRefreshing = false;
   }
 

--- a/src/core/intelligence/repo-map.ts
+++ b/src/core/intelligence/repo-map.ts
@@ -435,7 +435,9 @@ export class RepoMap {
            symbol_name = COALESCE((SELECT s.name FROM symbols s WHERE s.id = semantic_summaries.symbol_id), '')
          WHERE file_path = '' AND symbol_id IN (SELECT id FROM symbols)`,
       );
-    } catch {}
+    } catch (e) {
+      console.error("[repo-map] backfillSummaryPaths failed:", e instanceof Error ? e.message : String(e));
+    }
   }
 
   private cleanOrphanedSummaries(): void {
@@ -446,7 +448,9 @@ export class RepoMap {
       this.db.run(
         "DELETE FROM semantic_summaries WHERE symbol_id NOT IN (SELECT id FROM symbols) AND (source != 'llm' OR file_path = '')",
       );
-    } catch {}
+    } catch (e) {
+      console.error("[repo-map] cleanOrphanedSummaries failed:", e instanceof Error ? e.message : String(e));
+    }
   }
 
   get isReady(): boolean {
@@ -2593,12 +2597,14 @@ export class RepoMap {
         try {
           const st = await statAsync(absPath);
           this.indexFile(absPath, relPath, st.mtimeMs, language);
-        } catch {}
+        } catch (e) {
+          this.onError?.(`reindex failed for ${relPath}: ${e instanceof Error ? e.message : String(e)}`);
+        }
       }
       this.markDirty();
     };
 
-    process().catch(() => {});
+    process().catch((e) => { console.error("[repo-map] flushReindex failed:", e instanceof Error ? e.message : String(e)); });
   }
 
   private markDirty(): void {
@@ -2655,7 +2661,9 @@ export class RepoMap {
       try {
         const content = readFileSync(join(this.cwd, file.path), "utf-8");
         fileContents.set(file.id, content.split("\n"));
-      } catch {}
+      } catch (e) {
+        console.error(`[repo-map] failed to read ${file.path} for call graph:`, e instanceof Error ? e.message : String(e));
+      }
       if (i % 20 === 19) await tick();
     }
 
@@ -4767,7 +4775,9 @@ export class RepoMap {
     if (this.flushPromise) {
       try {
         await this.flushPromise;
-      } catch {}
+      } catch (e) {
+        console.error("[repo-map] error awaiting pending flush during close:", e instanceof Error ? e.message : String(e));
+      }
     }
     this.db.close();
   }

--- a/src/hearth/daemon.ts
+++ b/src/hearth/daemon.ts
@@ -193,12 +193,16 @@ export class HearthDaemon {
     if (existsSync(this.config.daemon.socketPath)) {
       try {
         unlinkSync(this.config.daemon.socketPath);
-      } catch {}
+      } catch (e) {
+        this.log(`failed to remove socket: ${e instanceof Error ? e.message : String(e)}`);
+      }
     }
     // Remove pidfile so the UI knows we're gone.
     try {
       unlinkSync(DEFAULT_PID_PATH);
-    } catch {}
+    } catch (e) {
+      this.log(`failed to remove pidfile: ${e instanceof Error ? e.message : String(e)}`);
+    }
     this.log("hearth stopped");
   }
 
@@ -360,7 +364,9 @@ export class HearthDaemon {
     if (existsSync(path)) {
       try {
         unlinkSync(path);
-      } catch {}
+      } catch (e) {
+        this.log(`failed to remove stale socket: ${e instanceof Error ? e.message : String(e)}`);
+      }
     }
     // Cache our euid once — every connection compares against this. Bun/Node
     // expose process.geteuid() on darwin+linux; fall back to process.getuid()
@@ -411,7 +417,9 @@ export class HearthDaemon {
       server.listen(path, () => {
         try {
           chmodSync(path, 0o600);
-        } catch {}
+        } catch (e) {
+          this.log(`failed to chmod socket: ${e instanceof Error ? e.message : String(e)}`);
+        }
         resolve();
       });
     });


### PR DESCRIPTION
## Summary

The codebase has 157+ empty `catch {}` blocks that silently discard errors, making debugging nearly impossible. This PR adds targeted error logging to the **13 most critical** ones, leaving ~140+ benign migration/permission catches untouched.

## Changes

### `src/core/intelligence/repo-map.ts` (6 changes)

| Catch Block | Context | Why Critical |
|---|---|---|
| `flushReindex` stat/indexFile | File reindexing on edit | Silent incomplete repo map |
| `flushReindex` process().catch | Flush promise rejection | Lost index updates |
| `backfillSummaryPaths` | Data migration for summaries | Silent data corruption |
| `cleanOrphanedSummaries` | Orphan cleanup query | Stale data accumulation |
| `buildCallGraph` file read | Call graph file I/O | Incomplete call graph silently |
| `close()` flushPromise | Pending DB flush on close | Silent data loss on shutdown |

### `src/core/context/manager.ts` (3 changes)

| Catch Block | Context | Why Critical |
|---|---|---|
| `generateSemanticSummaries` | LLM summary generation (fire-and-forget) | Major feature failing silently |
| `prefetchDiffBlock` | Diff block for changed files | Missing diff context for LLM |
| `warmRepoMapCache` | Repo map cache warm-up | Stale/empty context for prompts |

### `src/hearth/daemon.ts` (4 changes)

| Catch Block | Context | Why Critical |
|---|---|---|
| `stop()` socketPath unlink | Daemon shutdown cleanup | Stale socket blocks restart |
| `stop()` pidfile unlink | Daemon shutdown cleanup | PID file prevents restart |
| `startSocket()` stale socket | Socket creation | Daemon fails to start |
| `startSocket()` chmodSync | Socket permissions (0o600) | Security: open socket permissions |

## Design Decisions

- **Used `console.error`** for repo-map and manager (no daemon logger available)
- **Used `this.log()`** for daemon (consistent with existing logging pattern, routes through redaction)
- **Used `this.onError?.()`** for flushReindex (existing error callback pattern in RepoMap)
- **All errors include `e.message`** for actionable diagnostics
- **Did not change** ~140+ benign catches (migrations that "column already exists", chmod permission fallbacks, etc.)

## Impact

- **Zero behavioral changes** — only adds logging, no flow changes
- **No new dependencies** — uses built-in `console.error` and existing `this.log()`
- **Helps triage** silent failures in the three most critical subsystems: intelligence indexing, context assembly, and daemon lifecycle