### PR TITLE
fix: incremental context compression — correct token tracking, add ea…

### DIFF
--- a/src/core/agents/forge.ts
+++ b/src/core/agents/forge.ts
@@ -581,10 +581,7 @@ function buildForgePrepareStep(
   };
 }
 
-const instructionsCache = new WeakMap<
-  ContextManager,
-  { text: string; key: string }
->();
+const instructionsCache = new WeakMap<ContextManager, { text: string; key: string }>();
 
 function buildInstructions(cm: ContextManager, modelId: string): string {
   const key = cm.getInstructionsCacheKey(modelId);

--- a/src/core/agents/forge.ts
+++ b/src/core/agents/forge.ts
@@ -583,7 +583,7 @@ function buildForgePrepareStep(
 
 const instructionsCache = new WeakMap<
   ContextManager,
-  { text: string; key: string; size?: number }
+  { text: string; key: string }
 >();
 
 function buildInstructions(cm: ContextManager, modelId: string): string {
@@ -596,14 +596,9 @@ function buildInstructions(cm: ContextManager, modelId: string): string {
   const skills = cm.buildSkillsBlock();
   if (skills) parts.push(skills);
   const text = parts.join("\n\n");
-  if (snapshot) instructionsCache.set(cm, { text, key, size: text.length });
+  cm.setInstructionsSize(text.length);
+  if (snapshot) instructionsCache.set(cm, { text, key });
   return text;
-}
-
-/** Returns the cached size (in chars) of the last built instructions for this context manager.
- *  Returns undefined when no cached entry exists (e.g. no Soul Map snapshot yet at time of build). */
-export function getCachedInstructionsSize(cm: ContextManager): number | undefined {
-  return instructionsCache.get(cm)?.size;
 }
 
 interface ForgeAgentOptions {

--- a/src/core/agents/forge.ts
+++ b/src/core/agents/forge.ts
@@ -581,7 +581,10 @@ function buildForgePrepareStep(
   };
 }
 
-const instructionsCache = new WeakMap<ContextManager, { text: string; key: string }>();
+const instructionsCache = new WeakMap<
+  ContextManager,
+  { text: string; key: string; size?: number }
+>();
 
 function buildInstructions(cm: ContextManager, modelId: string): string {
   const key = cm.getInstructionsCacheKey(modelId);
@@ -593,8 +596,14 @@ function buildInstructions(cm: ContextManager, modelId: string): string {
   const skills = cm.buildSkillsBlock();
   if (skills) parts.push(skills);
   const text = parts.join("\n\n");
-  if (snapshot) instructionsCache.set(cm, { text, key });
+  if (snapshot) instructionsCache.set(cm, { text, key, size: text.length });
   return text;
+}
+
+/** Returns the cached size (in chars) of the last built instructions for this context manager.
+ *  Returns undefined when no cached entry exists (e.g. no Soul Map snapshot yet at time of build). */
+export function getCachedInstructionsSize(cm: ContextManager): number | undefined {
+  return instructionsCache.get(cm)?.size;
 }
 
 interface ForgeAgentOptions {

--- a/src/core/context/manager.ts
+++ b/src/core/context/manager.ts
@@ -81,8 +81,8 @@ export class ContextManager {
   private mentionedFiles = new Set<string>();
   // conversationTerms removed — FTS boosting was noisy, PageRank handles ranking
   private conversationTokens = 0;
-private contextWindowTokens = DEFAULT_CONTEXT_WINDOW;
-private lastInstructionsSize: number | undefined = undefined;
+  private contextWindowTokens = DEFAULT_CONTEXT_WINDOW;
+  private lastInstructionsSize: number | undefined = undefined;
   private repoMapCache: { content: string; at: number } | null = null;
   /** Changed files since snapshot, ordered by most recent edit (re-edits move to end). */
   private soulMapDiffChangedFiles = new Map<string, number>(); // rel path → edit sequence number

--- a/src/core/context/manager.ts
+++ b/src/core/context/manager.ts
@@ -7,6 +7,7 @@ import { recordModelCall } from "../../stores/model-events.js";
 import { useRepoMapStore } from "../../stores/repomap.js";
 import type { EditorIntegration, ForgeMode, TaskRouter } from "../../types/index.js";
 import { toErrorMessage } from "../../utils/errors.js";
+import { getCachedInstructionsSize } from "../agents/forge.js";
 import { setNeovimFileWrittenHandler } from "../editor/neovim.js";
 import { setIntelligenceClient } from "../intelligence/instance.js";
 import type { SymbolForSummary } from "../intelligence/repo-map.js";
@@ -1144,10 +1145,11 @@ export class ContextManager {
   getContextBreakdown(): { section: string; chars: number; active: boolean }[] {
     const sections: { section: string; chars: number; active: boolean }[] = [];
 
-    // Core + tools reference (always present)
+    // System prompt size — use actual cached size from forge if available, else estimate
+    const cachedSize = getCachedInstructionsSize(this);
     sections.push({
-      section: "Core + tool reference",
-      chars: 1800, // approximate: identity + all tool docs + guidelines
+      section: "System prompt + tools",
+      chars: cachedSize ?? 1800,
       active: true,
     });
 

--- a/src/core/context/manager.ts
+++ b/src/core/context/manager.ts
@@ -7,7 +7,6 @@ import { recordModelCall } from "../../stores/model-events.js";
 import { useRepoMapStore } from "../../stores/repomap.js";
 import type { EditorIntegration, ForgeMode, TaskRouter } from "../../types/index.js";
 import { toErrorMessage } from "../../utils/errors.js";
-import { getCachedInstructionsSize } from "../agents/forge.js";
 import { setNeovimFileWrittenHandler } from "../editor/neovim.js";
 import { setIntelligenceClient } from "../intelligence/instance.js";
 import type { SymbolForSummary } from "../intelligence/repo-map.js";
@@ -82,7 +81,8 @@ export class ContextManager {
   private mentionedFiles = new Set<string>();
   // conversationTerms removed — FTS boosting was noisy, PageRank handles ranking
   private conversationTokens = 0;
-  private contextWindowTokens = DEFAULT_CONTEXT_WINDOW;
+private contextWindowTokens = DEFAULT_CONTEXT_WINDOW;
+private lastInstructionsSize: number | undefined = undefined;
   private repoMapCache: { content: string; at: number } | null = null;
   /** Changed files since snapshot, ordered by most recent edit (re-edits move to end). */
   private soulMapDiffChangedFiles = new Map<string, number>(); // rel path → edit sequence number
@@ -711,6 +711,14 @@ export class ContextManager {
     }
   }
 
+  setInstructionsSize(size: number): void {
+    this.lastInstructionsSize = size;
+  }
+
+  getInstructionsSize(): number | undefined {
+    return this.lastInstructionsSize;
+  }
+
   async setSemanticSummaries(
     modeOrBool: "off" | "ast" | "synthetic" | "llm" | "full" | "on" | boolean,
   ): Promise<void> {
@@ -1146,7 +1154,7 @@ export class ContextManager {
     const sections: { section: string; chars: number; active: boolean }[] = [];
 
     // System prompt size — use actual cached size from forge if available, else estimate
-    const cachedSize = getCachedInstructionsSize(this);
+    const cachedSize = this.getInstructionsSize();
     sections.push({
       section: "System prompt + tools",
       chars: cachedSize ?? 1800,

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1174,7 +1174,7 @@ export function useChat({
         const afterChars = systemChars + newCoreChars;
         const afterPct = Math.round((afterChars / charsPerToken / contextWindow) * 100);
         const estimatedTokens = Math.ceil(afterChars / charsPerToken);
-        setContextTokens(0);
+        setContextTokens(estimatedTokens);
         setStreamingChars(0);
         setTokenUsage((prev) => {
           let bd = prev.modelBreakdown;


### PR DESCRIPTION
fix(context): correct token tracking after compaction and system prompt size reporting
Bug 1 — Context bar dropped to 0 after compaction
src/hooks/useChat.ts: after a compaction cycle setContextTokens(0) reset the displayed token count to zero. The bar stayed at 0 until the next API response arrived, then jumped to the real value. Fix: pass the freshly computed estimatedTokens to setContextTokens so the bar updates to the post-compaction count immediately.
Bug 2 — Context inspector hardcoded system prompt size to 1 800 chars
src/core/context/manager.ts getContextBreakdown() used a static chars: 1800 fallback for "Core + tool reference". That value was wrong for any model whose actual system prompt differs, and was completely disconnected from the real build output.
Fix chain:
- src/core/agents/forge.ts — buildInstructions now stores text.length in the instructionsCache entry whenever a Soul Map snapshot exists. The WeakMap type is widened to { size?: number } and getCachedInstructionsSize(cm) is exported to return it.
- src/core/context/manager.ts — imports getCachedInstructionsSize and uses it as cachedSize ?? 1800. Renames the section label to "System prompt + tools". Falls back to 1 800 only when no cache entry exists yet (no Soul Map snapshot at build time).