### PR TITLE
Fix/gpt 5.5 context windows

### DIFF
--- a/src/core/llm/models.ts
+++ b/src/core/llm/models.ts
@@ -77,27 +77,25 @@ export function matchesContextOverride(model: string, pattern: string): boolean 
   );
 }
 
+function findContextOverride(
+  provider: ReturnType<typeof getProvider>,
+  model: string,
+): number | undefined {
+  if (!provider?.contextWindowOverrides) return undefined;
+
+  for (const [pattern, tokens] of provider.contextWindowOverrides) {
+    if (matchesContextOverride(model, pattern)) return tokens;
+  }
+
+  return undefined;
+}
+
 export function applyProviderContextOverride(
   providerId: string,
   model: ProviderModelInfo,
 ): ProviderModelInfo {
-  const provider = getProvider(providerId);
-  if (!provider?.contextWindowOverrides) return model;
-
-  for (const [pattern, tokens] of provider.contextWindowOverrides) {
-    if (matchesContextOverride(model.id, pattern)) {
-      return { ...model, contextWindow: tokens };
-    }
-  }
-
-  return model;
-}
-
-function applyProviderContextOverrides(
-  providerId: string,
-  models: ProviderModelInfo[],
-): ProviderModelInfo[] {
-  return models.map((m) => applyProviderContextOverride(providerId, m));
+  const tokens = findContextOverride(getProvider(providerId), model.id);
+  return tokens ? { ...model, contextWindow: tokens } : model;
 }
 
 /**
@@ -123,11 +121,12 @@ export function getModelContextInfoSync(modelId: string): ContextWindowResult {
   // 0. Provider-specific overrides for known-incorrect upstream API values
   //    (e.g. OpenRouter lists GLM-5 as 80k, actual ~200k)
   const ownProvider = providerId ? getProvider(providerId) : null;
-  if (ownProvider?.contextWindowOverrides) {
-    for (const [pattern, tokens] of ownProvider.contextWindowOverrides) {
-      if (matchesContextOverride(model, pattern)) return { tokens, source: "override" };
-    }
-  }
+  const overrideTokens = providerId
+    ? findContextOverride(ownProvider ?? undefined, model)
+    : getAllProviders()
+        .map((provider) => findContextOverride(provider, model))
+        .find((tokens) => tokens !== undefined);
+  if (overrideTokens) return { tokens: overrideTokens, source: "override" };
 
   // 1. Provider's own API data (most accurate)
   if (providerId && !ownProvider?.grouped) {
@@ -442,11 +441,13 @@ export async function fetchProviderModels(
   try {
     const models = await provider.fetchModels();
     if (models) {
-      const normalized = applyProviderContextOverrides(providerId, models);
+      const normalized = models.map((m) => applyProviderContextOverride(providerId, m));
       modelCache.set(providerId, { models: normalized, ts: Date.now() });
       return { models: normalized };
     }
-    return { models: applyProviderContextOverrides(providerId, provider.fallbackModels) };
+    return {
+      models: provider.fallbackModels.map((m) => applyProviderContextOverride(providerId, m)),
+    };
   } catch (err) {
     const msg = toErrorMessage(err);
     return { models: [], error: `API error: ${msg}` };

--- a/src/core/llm/models.ts
+++ b/src/core/llm/models.ts
@@ -65,7 +65,7 @@ interface ContextWindowResult {
   source: ContextWindowSource;
 }
 
-function matchesContextOverride(model: string, pattern: string): boolean {
+export function matchesContextOverride(model: string, pattern: string): boolean {
   const lowerModel = model.toLowerCase();
   const lowerPattern = pattern.toLowerCase();
   const bareModel = lowerModel.split("/").pop() ?? lowerModel;
@@ -75,6 +75,29 @@ function matchesContextOverride(model: string, pattern: string): boolean {
     lowerModel === lowerPattern ||
     lowerModel.endsWith(`/${lowerPattern}`)
   );
+}
+
+export function applyProviderContextOverride(
+  providerId: string,
+  model: ProviderModelInfo,
+): ProviderModelInfo {
+  const provider = getProvider(providerId);
+  if (!provider?.contextWindowOverrides) return model;
+
+  for (const [pattern, tokens] of provider.contextWindowOverrides) {
+    if (matchesContextOverride(model.id, pattern)) {
+      return { ...model, contextWindow: tokens };
+    }
+  }
+
+  return model;
+}
+
+function applyProviderContextOverrides(
+  providerId: string,
+  models: ProviderModelInfo[],
+): ProviderModelInfo[] {
+  return models.map((m) => applyProviderContextOverride(providerId, m));
 }
 
 /**
@@ -419,10 +442,11 @@ export async function fetchProviderModels(
   try {
     const models = await provider.fetchModels();
     if (models) {
-      modelCache.set(providerId, { models, ts: Date.now() });
-      return { models };
+      const normalized = applyProviderContextOverrides(providerId, models);
+      modelCache.set(providerId, { models: normalized, ts: Date.now() });
+      return { models: normalized };
     }
-    return { models: provider.fallbackModels };
+    return { models: applyProviderContextOverrides(providerId, provider.fallbackModels) };
   } catch (err) {
     const msg = toErrorMessage(err);
     return { models: [], error: `API error: ${msg}` };
@@ -702,11 +726,13 @@ async function fetchProxyGrouped(): Promise<GroupedModelsResult> {
       const ctxWindow =
         m.context_length ?? anthropicCtx.get(m.id) ?? findOpenRouterModel(m.id)?.context_length;
 
-      grouped[group].push({
-        id: m.id,
-        name: m.id,
-        contextWindow: ctxWindow,
-      });
+      grouped[group].push(
+        applyProviderContextOverride("proxy", {
+          id: m.id,
+          name: m.id,
+          contextWindow: ctxWindow,
+        }),
+      );
     }
 
     const subProviders: SubProvider[] = Object.keys(grouped)

--- a/src/core/llm/models.ts
+++ b/src/core/llm/models.ts
@@ -58,11 +58,23 @@ onProvidersChanged(() => {
 const DEFAULT_CONTEXT_TOKENS = 128_000;
 const METADATA_FETCH_TIMEOUT = 5_000;
 
-type ContextWindowSource = "api" | "openrouter" | "fallback";
+type ContextWindowSource = "api" | "openrouter" | "fallback" | "override";
 
 interface ContextWindowResult {
   tokens: number;
   source: ContextWindowSource;
+}
+
+function matchesContextOverride(model: string, pattern: string): boolean {
+  const lowerModel = model.toLowerCase();
+  const lowerPattern = pattern.toLowerCase();
+  const bareModel = lowerModel.split("/").pop() ?? lowerModel;
+  const barePattern = lowerPattern.split("/").pop() ?? lowerPattern;
+  return (
+    bareModel === barePattern ||
+    lowerModel === lowerPattern ||
+    lowerModel.endsWith(`/${lowerPattern}`)
+  );
 }
 
 /**
@@ -90,7 +102,7 @@ export function getModelContextInfoSync(modelId: string): ContextWindowResult {
   const ownProvider = providerId ? getProvider(providerId) : null;
   if (ownProvider?.contextWindowOverrides) {
     for (const [pattern, tokens] of ownProvider.contextWindowOverrides) {
-      if (model.includes(pattern)) return { tokens, source: "fallback" };
+      if (matchesContextOverride(model, pattern)) return { tokens, source: "override" };
     }
   }
 

--- a/src/core/llm/providers/codex/index.ts
+++ b/src/core/llm/providers/codex/index.ts
@@ -14,14 +14,22 @@ import {
   serializeCodexPrompt,
 } from "./runner.js";
 
+const GPT_55_INPUT_CONTEXT = 272_000;
+
 export const CODEX_FALLBACK_MODELS: ProviderModelInfo[] = [
+  { id: "gpt-5.5", name: "GPT-5.5", contextWindow: GPT_55_INPUT_CONTEXT },
   { id: "gpt-5.4", name: "GPT-5.4", contextWindow: 1_050_000 },
   { id: "gpt-5.2-codex", name: "GPT-5.2-Codex", contextWindow: 400_000 },
 ];
 
 export const CODEX_CONTEXT_WINDOWS: [pattern: string, tokens: number][] = [
+  ["gpt-5.5", GPT_55_INPUT_CONTEXT],
   ["gpt-5.4", 1_050_000],
   ["gpt-5.2-codex", 400_000],
+];
+
+const CODEX_CONTEXT_WINDOW_OVERRIDES: [pattern: string, tokens: number][] = [
+  ["gpt-5.5", GPT_55_INPUT_CONTEXT],
 ];
 
 export const codex: ProviderDefinition = {
@@ -51,6 +59,7 @@ export const codex: ProviderDefinition = {
   },
   fallbackModels: CODEX_FALLBACK_MODELS,
   contextWindows: CODEX_CONTEXT_WINDOWS,
+  contextWindowOverrides: CODEX_CONTEXT_WINDOW_OVERRIDES,
   checkAvailability: async () => {
     const status = getCodexLoginStatus();
     return status.installed && status.loggedIn;

--- a/src/core/llm/providers/proxy.ts
+++ b/src/core/llm/providers/proxy.ts
@@ -9,6 +9,7 @@ import { createReasoningFetchWrapper } from "./reasoning-fetch.js";
 import type { ProviderDefinition, ProviderModelInfo } from "./types.js";
 
 const baseURL = process.env.PROXY_API_URL || "http://127.0.0.1:8317/v1";
+const GPT_55_INPUT_CONTEXT = 272_000;
 
 function isAnthropicModel(modelId: string): boolean {
   return modelId.toLowerCase().startsWith("claude");
@@ -74,7 +75,10 @@ export const proxy: ProviderDefinition = {
     { id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4" },
     { id: "claude-opus-4-20250514", name: "Claude Opus 4" },
     { id: "claude-haiku-3-5-20241022", name: "Claude Haiku 3.5" },
+    { id: "gpt-5.5", name: "GPT-5.5", contextWindow: GPT_55_INPUT_CONTEXT },
   ],
+
+  contextWindowOverrides: [["gpt-5.5", GPT_55_INPUT_CONTEXT]],
 
   // Specific overrides first → shared patterns → generic catch-alls last.
   contextWindows: [
@@ -99,6 +103,7 @@ export const proxy: ProviderDefinition = {
     ["claude-3.5-haiku", 200_000],
     ["claude-3-5-haiku", 200_000],
     // GPT
+    ["gpt-5.5", GPT_55_INPUT_CONTEXT],
     ["gpt-5-chat", 128_000],
     ["gpt-4.1", 1_048_576],
     // Grok

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -510,22 +510,23 @@ export function useChat({
   }, [coAuthorCommits]);
 
   // Sync context window size to contextManager + status bar store.
-  // Pin per model — never downgrade if API cache expires (prevents 1M→200k drop).
+  // Pin per model, but allow provider overrides/API metadata to replace stale values.
   const contextManagerRef = useRef(contextManager);
   contextManagerRef.current = contextManager;
   const pinnedContextWindow = useRef(new Map<string, number>());
 
   // Context window: show sync fallback immediately, then correct from async API data.
   // The sync fallback comes from hardcoded patterns (per-provider, never cross-provider).
-  // The async fetch gets the real value from the provider API or OpenRouter metadata.
+  // The async fetch gets the real value from provider overrides, provider API, or OpenRouter metadata.
   const prevSyncedModel = useRef("");
   if (activeModel !== prevSyncedModel.current && activeModel !== "none") {
     prevSyncedModel.current = activeModel;
+    const { tokens: sync, source } = getModelContextInfoSync(activeModel);
     const cached = pinnedContextWindow.current.get(activeModel);
-    const sync = cached || getModelContextInfoSync(activeModel).tokens;
-    pinnedContextWindow.current.set(activeModel, sync);
-    contextManagerRef.current.setContextWindow(sync);
-    if (visible) useStatusBarStore.getState().setContextWindow(sync);
+    const next = source === "fallback" ? (cached ?? sync) : sync;
+    pinnedContextWindow.current.set(activeModel, next);
+    contextManagerRef.current.setContextWindow(next);
+    if (visible) useStatusBarStore.getState().setContextWindow(next);
   }
 
   // Async fetch — resolves the authoritative context window from provider API.
@@ -537,7 +538,7 @@ export function useChat({
     getModelContextInfo(activeModelForEffect).then(({ tokens: accurate, source }) => {
       if (cancelled) return;
       const prev = pinnedContextWindow.current.get(activeModelForEffect) ?? 0;
-      // API/OpenRouter data is authoritative — replace even if lower than fallback estimate.
+      // Provider overrides/API/OpenRouter data are authoritative — replace even if lower than fallback estimate.
       // Fallback data only upgrades (never downgrades) since it's a guess.
       const best = source !== "fallback" ? accurate : Math.max(prev, accurate);
       if (best !== prev) {
@@ -1346,8 +1347,8 @@ export function useChat({
     if (effectiveConfig.compaction?.strategy === "disabled") return;
     if (activeModelRef.current === "none") return;
     if (contextTokens <= 0) return;
-    // Only use pinned value (set by async fetch). If async hasn't resolved yet,
-    // skip this check — better to delay compaction than trigger on a wrong fallback.
+    // Only use pinned value (set by sync override/fallback or async metadata).
+    // If no pinned value exists yet, delay compaction rather than guess.
     const ctxWindow = pinnedContextWindow.current.get(activeModelRef.current);
     if (!ctxWindow) return;
     const pct = contextTokens / ctxWindow;

--- a/tests/codex-provider.test.ts
+++ b/tests/codex-provider.test.ts
@@ -37,10 +37,12 @@ describe("codex provider", () => {
     expect(codex.badge).toBe("non-streaming");
     expect(codex.onRequestAuth).toBeDefined();
     expect(codex.fallbackModels).toEqual([
+      { id: "gpt-5.5", name: "GPT-5.5", contextWindow: 272_000 },
       { id: "gpt-5.4", name: "GPT-5.4", contextWindow: 1_050_000 },
       { id: "gpt-5.2-codex", name: "GPT-5.2-Codex", contextWindow: 400_000 },
     ]);
     expect(codex.contextWindows).toEqual([
+      ["gpt-5.5", 272_000],
       ["gpt-5.4", 1_050_000],
       ["gpt-5.2-codex", 400_000],
     ]);

--- a/tests/provider-model-context.test.ts
+++ b/tests/provider-model-context.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import {
+  applyProviderContextOverride,
+  matchesContextOverride,
+} from "../src/core/llm/models.js";
+import { codex } from "../src/core/llm/providers/codex.js";
+
+const GPT_55_INPUT_CONTEXT = 272_000;
+
+describe("provider model context normalization", () => {
+  test("matches exact and provider-prefixed override IDs", () => {
+    expect(matchesContextOverride("gpt-5.5", "gpt-5.5")).toBe(true);
+    expect(matchesContextOverride("openai/gpt-5.5", "gpt-5.5")).toBe(true);
+    expect(matchesContextOverride("gpt-5.5-pro", "gpt-5.5")).toBe(false);
+  });
+
+  test("normalizes proxy gpt-5.5 context from upstream metadata", () => {
+    expect(
+      applyProviderContextOverride("proxy", {
+        id: "gpt-5.5",
+        name: "gpt-5.5",
+        contextWindow: 1_000_000,
+      }).contextWindow,
+    ).toBe(GPT_55_INPUT_CONTEXT);
+
+    expect(
+      applyProviderContextOverride("proxy", {
+        id: "openai/gpt-5.5",
+        name: "openai/gpt-5.5",
+        contextWindow: 1_000_000,
+      }).contextWindow,
+    ).toBe(GPT_55_INPUT_CONTEXT);
+  });
+
+  test("does not apply gpt-5.5 override to gpt-5.5-pro", () => {
+    expect(
+      applyProviderContextOverride("proxy", {
+        id: "gpt-5.5-pro",
+        name: "gpt-5.5-pro",
+        contextWindow: 1_000_000,
+      }).contextWindow,
+    ).toBe(1_000_000);
+  });
+
+  test("normalizes codex gpt-5.5 when fetched model omits context", () => {
+    expect(
+      applyProviderContextOverride("codex", {
+        id: "gpt-5.5",
+        name: "gpt-5.5",
+      }).contextWindow,
+    ).toBe(GPT_55_INPUT_CONTEXT);
+
+    expect(codex.fallbackModels.find((m) => m.id === "gpt-5.5")?.contextWindow).toBe(
+      GPT_55_INPUT_CONTEXT,
+    );
+  });
+});

--- a/tests/provider-model-context.test.ts
+++ b/tests/provider-model-context.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   applyProviderContextOverride,
+  getModelContextInfoSync,
   matchesContextOverride,
 } from "../src/core/llm/models.js";
 import { codex } from "../src/core/llm/providers/codex.js";
@@ -12,6 +13,13 @@ describe("provider model context normalization", () => {
     expect(matchesContextOverride("gpt-5.5", "gpt-5.5")).toBe(true);
     expect(matchesContextOverride("openai/gpt-5.5", "gpt-5.5")).toBe(true);
     expect(matchesContextOverride("gpt-5.5-pro", "gpt-5.5")).toBe(false);
+  });
+
+  test("resolves bare gpt-5.5 sync context as an override", () => {
+    expect(getModelContextInfoSync("gpt-5.5")).toEqual({
+      tokens: GPT_55_INPUT_CONTEXT,
+      source: "override",
+    });
   });
 
   test("normalizes proxy gpt-5.5 context from upstream metadata", () => {

--- a/tests/provider-model-context.test.ts
+++ b/tests/provider-model-context.test.ts
@@ -4,7 +4,7 @@ import {
   getModelContextInfoSync,
   matchesContextOverride,
 } from "../src/core/llm/models.js";
-import { codex } from "../src/core/llm/providers/codex.js";
+import { codex } from "../src/core/llm/providers/codex/index.js";
 
 const GPT_55_INPUT_CONTEXT = 272_000;
 


### PR DESCRIPTION
<!--
Read CONTRIBUTING.md before opening this PR.

Out-of-scope PRs are closed without review. Out of scope means:
  - src/core/intelligence/, src/core/agents/, src/core/context/manager.ts
  - src/core/prompts/, src/core/memory/recall.ts, src/core/compaction/
  - src/hearth/ server internals
  - New tools, new agents, new commands

For architecture proposals: open a Discussion, not a PR.
-->

## What

Fix `gpt-5.5` context limit for Codex/proxy: 272k input tokens, including runtime compaction and model picker display.

## Why

Codex/proxy model name is `gpt-5.5`, not `gpt-5.5-pro`. They do not get OpenAI API 1M context. Real usable input budget is 272k tokens. Before this PR, proxy/Codex could keep stale/upstream 1M metadata, so context math, auto-compaction, and picker display showed wrong limit. This adds provider-specific override for `gpt-5.5`, applies it everywhere context is resolved, and avoids matching `gpt-5.5-pro`.

## Scope check

- [x] I read `CONTRIBUTING.md` and this PR is in the **In scope** table.
- [x] This PR does not touch any path in the **Out of scope** list.
- [x] One feature or fix per PR (no drive-by refactors).
- [x] `bun run lint:fix && bun run format && bun run typecheck` passes.
- [x] If behavior changed, a test was added or updated.

## Verification

Ran:
```sh
bun test tests/provider-model-context.test.ts
bun run typecheck
bun run lint
```
Test covers:
- exact `gpt-5.5` match
- provider-prefixed `openai/gpt-5.5` match
- no accidental `gpt-5.5-pro` match
- Codex/proxy `gpt-5.5` normalized to 272k tokens
