### PR TITLE
Fix/stall retry reset

### DIFF
--- a/src/core/agents/subagent-tools.ts
+++ b/src/core/agents/subagent-tools.ts
@@ -839,7 +839,11 @@ export function buildSubagentTools(models: SubagentModels) {
               abortSignal,
             );
             if (!doneResult && !bus.getResult(task.agentId)?.success) {
-              throw new Error(resultText);
+              return {
+                reads: bus.getFileReadRecords(task.agentId),
+                filesEdited: [...bus.getEditedFiles(task.agentId).keys()],
+                output: `[Dispatch failed] ${resultText}`,
+              } satisfies DispatchOutput;
             }
             const editedMap = bus.getEditedFiles(task.agentId);
 

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1969,6 +1969,7 @@ export function useChat({
         completedResultChars.clear();
         stallTriggered = false;
         stallAborted = false;
+        stallRetryPendingRef.current = false;
 
         try {
           setIsLoading(true);

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1967,6 +1967,8 @@ export function useChat({
         finalSegments.length = 0;
         subagentCumulative.clear();
         completedResultChars.clear();
+        stallTriggered = false;
+        stallAborted = false;
 
         try {
           setIsLoading(true);
@@ -3565,11 +3567,11 @@ export function useChat({
             // 1. finally block doesn't fire competing handleSubmit (messageQueue/compact)
             // 2. next handleSubmit("Continue.") preserves the retry count
             stallRetryPendingRef.current = true;
-            // Backoff: 2s first, 5s second
+            // Backoff: 2s first, 5s second (use await so the finally block runs cleanly
+            // before we re-enter the retry loop with fresh state).
             const backoffMs = stallRetryCountRef.current === 1 ? 2_000 : 5_000;
-            setTimeout(() => handleSubmitRef.current("Continue."), backoffMs);
-            // Skip the rest of the catch — finally block will clean up
-            return;
+            await new Promise((resolve) => setTimeout(resolve, backoffMs));
+            continue;
           }
 
           const rawMsg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
…erry-pick from custom PR)

1. retry: stall-retry stuck at 1 — setTimeout+return bypassed finally (useChat.ts)

   The stall-retry path in the catch block used:
     setTimeout(() => handleSubmitRef.current("Continue."), backoffMs); return;
   The bare return exits the catch handler WITHOUT the finally block running,
   leaving abortRef.current non-null, isLoading true, and the Stop hook dangling.
   When the timer fires handleSubmit("Continue.") the concurrency-guard intercepts
   the stale abortRef and silently drops the retry.  stallRetryCountRef never
   advanced past its first watchdog tick, leaving the UI counter perpetually at 1/N.
   Fix: replace setTimeout+return with await delay; continue; so the finally block
   runs first (clearing all gates) before the loop re-enters cleanly.

2. retry: stallTriggered sticky across retry-loop iterations (useChat.ts)

   stallTriggered was set to true by the stall-watch setInterval callback (line ~2504)
   and was never reset to false inside the for-loop body. After the first stall it
   stayed true forever, making isStallExhausted fire on every subsequent abort
   before any fresh stall could accumulate ticks — the counter advanced via the
   watchdog but isStallExhausted hijacked the slot through the fallback/error path
   every time.
   Fix: reset stallTriggered=false and stallAborted=false at the top of every loop
   iteration alongside the existing userAbortedRef/abortRef resets.

3. dispatch: single-agent throw crashes parent forge loop (subagent-tools.ts:843)

   The single-agent dispatch path did:
     if (!doneResult && !bus.getResult(task.agentId)?.success)
       throw new Error(resultText);
   The throw is uncaught, aborting the parent forge loop with no structured output.
   The multi-agent path already handles failures gracefully — never throws, embeds
   agent errors in result text.
   Fix: return a DispatchOutput with the error body ({ reads, filesEdited,
   output: "[Dispatch failed] {resultText}" }) so the forge loop surfaces the
   failure as structured text and its own retry/fallback logic can fire.