### PR TITLE
feat: add Late Night theme

### DIFF
--- a/src/core/theme/tokens.ts
+++ b/src/core/theme/tokens.ts
@@ -1718,6 +1718,47 @@ const PROXYSOUL_WATER: ThemeTokens = {
   accentAssistant: "#00a2ce",
 };
 
+export const LATE_NIGHT: ThemeTokens = {
+  ...DARK_THEME,
+  brand: "#7C6FD4",
+  brandSecondary: "#A89EE8",
+  brandDim: "#2D2850",
+  brandAlt: "#C4BCEF",
+  error: "#E05C6A",
+  success: "#5DBB8A",
+  warning: "#E2C08D",
+  info: "#5B9BD4",
+  amber: "#C9894A",
+  textPrimary: "#EEEAE3",
+  textSecondary: "#B8B3AA",
+  textMuted: "#847F78",
+  textDim: "#5C5852",
+  textFaint: "#3A3833",
+  textSubtle: "#6B6762",
+  bgApp: "#0A0A0C",
+  bgPrimary: "#0F0F12",
+  bgSecondary: "#141417",
+  bgElevated: "#1A1A1F",
+  bgPopup: "#1C1C22",
+  bgPopupHighlight: "#25252D",
+  bgOverlay: "#0A0A0C",
+  bgInput: "#16161B",
+  bgBanner: "#1A1A1F",
+  bgBannerError: "#1F1218",
+  bgUser: "#141420",
+  border: "#222228",
+  borderFocused: "#7C6FD4",
+  borderActive: "#A89EE8",
+  borderSlash: "#2E2E38",
+  diffAddedBg: "#0E1F16",
+  diffRemovedBg: "#1F0E12",
+  diffAddedSign: "#5DBB8A",
+  diffRemovedSign: "#E05C6A",
+  accentUser: "#3a79e2",
+  accentAssistant: "#d061fc",
+  accentSystem: "#3A3845",
+};
+
 /** Theme metadata for the picker UI */
 export interface ThemeMeta {
   label: string;
@@ -1874,6 +1915,11 @@ export const THEME_META: Record<string, ThemeMeta> = {
     description: "Midnight amber & golden warmth",
     variant: "dark",
   },
+  "late-night": {
+    label: "Late Night",
+    description: "Premium near-black with cyan and indigo — built for long sessions",
+    variant: "dark",
+  },
 };
 
 export const BUILTIN_THEMES: Record<string, ThemeTokens> = {
@@ -1913,6 +1959,7 @@ export const BUILTIN_THEMES: Record<string, ThemeTokens> = {
   iceberg: ICEBERG,
   ember: EMBER,
   vesper: VESPER,
+  "late-night": LATE_NIGHT,
 };
 
 /** Convert kebab-case token key to camelCase (e.g. "bg-primary" → "bgPrimary") */


### PR DESCRIPTION
## What
Adds Late Night, a new built-in dark theme optimized for long coding sessions.

## Why
Existing dark themes either use generic grays that strain the eyes or vibrant 
colors too aggressive for night use. Late Night uses near-black backgrounds with 
warm undertones, desaturated violet brand accent, and a carefully stepped 6-tier 
text hierarchy for comfortable extended use.

## Scope check
- [x] I read `CONTRIBUTING.md` and this PR is in the **In scope** table.
- [x] This PR does not touch any path in the **Out of scope** list.
- [x] One feature or fix per PR (no drive-by refactors).
- [x] `bun run lint:fix && bun run format && bun run typecheck` passes.
- [ ] If behavior changed, a test was added or updated.

## Verification
- Added `LATE_NIGHT` constant to `src/core/theme/tokens.ts` using `...DARK_THEME` spread
- Registered in `THEME_META` with label, description, and `variant: "dark"`
- Registered in `BUILTIN_THEMES` as `"late-night"`
- `bun run lint:fix && bun run format && bun run typecheck` all pass clean
- Tested live in SoulForge via `/theme late-night`