### PR TITLE
feat(providers): SuperGrok OAuth subscription provider

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -197,6 +197,36 @@ at runtime — not linked into or distributed with SoulForge. This is standard u
 
 ---
 
+## Ported / Adapted Source
+
+### progrok (MIT) — xAI OAuth device-code helpers
+
+Portions of the SuperGrok OAuth provider (`src/core/llm/providers/grok/`) are adapted from
+[lidge-jun/progrok](https://github.com/lidge-jun/progrok) auth modules (device-code flow,
+OIDC discovery trust checks, token store refresh). Original work is MIT-licensed.
+
+Copyright (c) progrok contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
 ## License Texts
 
 ### Apache License 2.0

--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -54,7 +54,8 @@
             "pages": [
               "providers/overview",
               "providers/custom",
-              "providers/copilot"
+              "providers/copilot",
+              "providers/grok"
             ]
           },
           {

--- a/mintlify-docs/providers/grok.mdx
+++ b/mintlify-docs/providers/grok.mdx
@@ -65,7 +65,7 @@ Not every Grok model is offered in every country on the subscription path. If a 
 
 ## Headless
 
-Headless / CI needs a prior interactive login so `xai-oauth.json` already exists. There is no non-interactive device-code printer in v1.
+Headless / CI needs a prior interactive login so `xai-oauth.json` already exists. There is no non-interactive device-code flow in v1.
 
 ```bash
 soulforge --headless --model grok/grok-4.3 "explain this file"

--- a/mintlify-docs/providers/grok.mdx
+++ b/mintlify-docs/providers/grok.mdx
@@ -1,0 +1,86 @@
+---
+title: "Grok (subscription)"
+description: "Use SuperGrok / X Premium+ with SoulForge via device-code OAuth — no xAI API key."
+icon: "bolt"
+---
+
+If you pay for **SuperGrok** or **X Premium+**, SoulForge can use Grok models through xAI's OAuth device-code flow. No API key, no separate progrok process.
+
+This is separate from the built-in **Grok** provider (`xai`), which uses a paid [console.x.ai](https://console.x.ai) API key.
+
+<Warning>
+Unofficial OAuth client shared by community tools (progrok / Hermes / OpenClaw lineage). Not endorsed by xAI. Terms of service and client acceptance may change without notice. Use at your own risk.
+</Warning>
+
+## Requirements
+
+- Active **SuperGrok** or **X Premium+** subscription that includes Grok API access via OAuth
+- Network access to `auth.x.ai` and `api.x.ai`
+
+## Setup
+
+<Steps>
+  <Step title="Log in inside SoulForge">
+    Run:
+
+    ```text
+    /grok login
+    ```
+
+    Or open the model picker (`Ctrl+L`), select **Grok (subscription)**, and press Enter when it shows *login required*.
+  </Step>
+
+  <Step title="Complete device-code auth">
+    SoulForge shows a URL and a short user code. Open the URL in a browser, sign in with your X / xAI account, and enter the code.
+  </Step>
+
+  <Step title="Pick a model">
+    Press `Ctrl+L`, choose **Grok (subscription)**, then a model such as `grok-4.3`.
+  </Step>
+</Steps>
+
+## Commands
+
+| Command | What it does |
+|---------|----------------|
+| `/grok` / `/grok status` | Show login status and account email (if present) |
+| `/grok login` | Start device-code OAuth |
+| `/grok logout` | Delete stored tokens |
+| `/grok switch` | Logout then login again |
+
+Tokens are stored at `{configDir}/xai-oauth.json` with mode `0600` (typically `~/.soulforge/xai-oauth.json` on Linux/macOS).
+
+## How this differs from other Grok paths
+
+| Path | Auth | When to use |
+|------|------|-------------|
+| **Grok (subscription)** (`grok/*`) | SuperGrok OAuth device-code | You have SuperGrok / X Premium+ and want no API key |
+| **Grok** (`xai/*`) | `XAI_API_KEY` from console.x.ai | Paid API usage, teams, automation |
+| **Proxy** `/proxy` + xAI login | CLIProxyAPI account | You already use the proxy addon for multiple chat subs |
+| **Custom progrok** | Your own OpenAI-compatible base URL | Advanced / VPN sidecar setups |
+
+## Regional availability
+
+Not every Grok model is offered in every country on the subscription path. If a model is missing from the picker or the API returns a region error, try a VPN to a supported region (often the US) and re-check with `Ctrl+L`.
+
+## Headless
+
+Headless / CI needs a prior interactive login so `xai-oauth.json` already exists. There is no non-interactive device-code printer in v1.
+
+```bash
+soulforge --headless --model grok/grok-4.3 "explain this file"
+```
+
+## Legal / risk notes
+
+<AccordionGroup>
+  <Accordion title="Unofficial client">
+    SoulForge uses a community OAuth client id also used by progrok and related tools. xAI may revoke or rate-limit unofficial clients.
+  </Accordion>
+  <Accordion title="Subscription vs API">
+    OAuth access is tied to your subscription tier and rate limits. This is not unlimited API access and is not a substitute for a console API key when you need guaranteed paid capacity.
+  </Accordion>
+  <Accordion title="Token storage">
+    Refresh tokens live on disk under your SoulForge config directory. Use `/grok logout` on shared machines.
+  </Accordion>
+</AccordionGroup>

--- a/mintlify-docs/providers/overview.mdx
+++ b/mintlify-docs/providers/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Providers"
-description: "21 built-in LLM providers, plus any OpenAI-compatible API."
+description: "22+ built-in LLM providers, plus any OpenAI-compatible API."
 icon: "plug"
 ---
 
-SoulForge ships 21 built-in providers. Set one key and go.
+SoulForge ships 23 built-in providers. Set one key and go.
 
 ## Cloud
 
@@ -34,6 +34,7 @@ SoulForge ships 21 built-in providers. Set one key and go.
 |----------|-----|-------|
 | **[GitHub Copilot](/providers/copilot)** | Your Copilot subscription | OAuth token from IDE |
 | **Codex** | ChatGPT subscription | `/codex login` inside SoulForge |
+| **[Grok (subscription)](/providers/grok)** | SuperGrok / X Premium+ | `/grok login` device-code OAuth |
 | **GitHub Models** | Free with any GitHub PAT | `soulforge --set-key github-models ghp_...` |
 
 ## Local (free)

--- a/src/components/modals/LlmSelector.tsx
+++ b/src/components/modals/LlmSelector.tsx
@@ -110,6 +110,11 @@ export function LlmSelector({ visible, activeModel, onSelect, onClose }: Props) 
     // "no key — press Enter to add" would be misleading.
     const visibleConfigs = PROVIDER_CONFIGS.filter((cfg) => {
       if (cfg.envVar !== "") return true; // key-based provider — always show
+      // Subscription providers with interactive login (Codex, Grok, …) must stay
+      // visible when logged out so Enter can run onRequestAuth. Only hide
+      // envVar-less providers that are purely auto-detected (proxy addon,
+      // Ollama daemon, etc.).
+      if (getProvider(cfg.id)?.onRequestAuth) return true;
       const avail = availability.get(cfg.id);
       // Hide only when explicitly unavailable. `undefined` (still checking) keeps it visible.
       return avail !== false;

--- a/src/core/commands/grok.ts
+++ b/src/core/commands/grok.ts
@@ -99,23 +99,42 @@ async function handleGrokStatus(_input: string, ctx: CommandContext): Promise<vo
 
 async function handleGrokLogout(_input: string, ctx: CommandContext): Promise<void> {
   const theme = getThemeTokens();
-  deleteTokens();
+  let result: { ok: boolean; message: string };
+  try {
+    deleteTokens();
+    result = { ok: true, message: "Logged out of Grok (subscription)." };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    result = { ok: false, message: `Logout failed: ${message}` };
+  }
   await refreshGrokState();
   const usingGrok = ctx.chat.activeModel.startsWith("grok/");
   ctx.openInfoPopup({
     title: "Grok Logout",
     icon: providerIcon("grok"),
-    lines: getGrokLogoutPopupLines(
-      { ok: true, message: "Logged out of Grok (subscription)." },
-      usingGrok,
-      theme,
-    ),
+    lines: getGrokLogoutPopupLines(result, usingGrok, theme),
   });
 }
 
 async function handleGrokSwitch(_input: string, ctx: CommandContext): Promise<void> {
   const theme = getThemeTokens();
-  deleteTokens();
+  try {
+    deleteTokens();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    ctx.openInfoPopup({
+      title: "Grok Switch Account",
+      icon: providerIcon("grok"),
+      lines: [
+        {
+          type: "text",
+          label: `Could not log out of the current Grok account: ${message}`,
+          color: theme.brandSecondary,
+        },
+      ],
+    });
+    return;
+  }
   await refreshGrokState();
   ctx.openInfoPopup({
     title: "Grok Switch Account",

--- a/src/core/commands/grok.ts
+++ b/src/core/commands/grok.ts
@@ -1,0 +1,140 @@
+import { providerIcon } from "../icons.js";
+import { invalidateProviderModelCache } from "../llm/models.js";
+import { checkProviders } from "../llm/provider.js";
+import { deleteTokens, getLoginStatus } from "../llm/providers/grok.js";
+import { getProvider } from "../llm/providers/index.js";
+import { getThemeTokens } from "../theme/index.js";
+import type { CommandContext, CommandHandler } from "./types.js";
+
+async function refreshGrokState(): Promise<void> {
+  invalidateProviderModelCache("grok");
+  await checkProviders().catch(() => {});
+}
+
+export function getGrokStatusPopupLines(
+  status: ReturnType<typeof getLoginStatus>,
+  theme: ReturnType<typeof getThemeTokens>,
+) {
+  return [
+    {
+      type: "entry" as const,
+      label: "Logged in",
+      desc: status.loggedIn ? "yes" : "no",
+      descColor: status.loggedIn ? theme.success : theme.warning,
+    },
+    {
+      type: "entry" as const,
+      label: "Account",
+      desc: status.email ?? (status.loggedIn ? "(unknown)" : "—"),
+    },
+    ...(status.expiresAt
+      ? [
+          {
+            type: "entry" as const,
+            label: "Access token expires",
+            desc: new Date(status.expiresAt).toLocaleString(),
+          },
+        ]
+      : []),
+    { type: "spacer" as const },
+    {
+      type: "text" as const,
+      label: status.loggedIn
+        ? "SuperGrok OAuth session is active. Pick a model with Ctrl+L."
+        : "Not logged in. Run /grok login (requires SuperGrok / X Premium+).",
+      color: status.loggedIn ? theme.textPrimary : theme.textSecondary,
+    },
+  ];
+}
+
+export function getGrokLogoutPopupLines(
+  result: { ok: boolean; message: string },
+  usingGrok: boolean,
+  theme: ReturnType<typeof getThemeTokens>,
+) {
+  return [
+    {
+      type: "text" as const,
+      label: result.message,
+      color: result.ok ? theme.success : theme.brandSecondary,
+    },
+    ...(usingGrok
+      ? [
+          { type: "spacer" as const },
+          {
+            type: "text" as const,
+            label:
+              "The active model is still Grok (subscription). Switch models or log back in before your next prompt.",
+            color: theme.textSecondary,
+          },
+        ]
+      : []),
+  ];
+}
+
+function showStatus(ctx: CommandContext): void {
+  const theme = getThemeTokens();
+  const status = getLoginStatus();
+  ctx.openInfoPopup({
+    title: "Grok Status",
+    icon: providerIcon("grok"),
+    lines: getGrokStatusPopupLines(status, theme),
+  });
+}
+
+async function handleGrokLogin(_input: string, _ctx: CommandContext): Promise<void> {
+  const provider = getProvider("grok");
+  if (!provider?.onRequestAuth) {
+    throw new Error("Grok auth flow is not available.");
+  }
+  // requestGrokAuth already refreshes providers, shows success + region note,
+  // and opens the model picker — same shape as /codex login.
+  await provider.onRequestAuth();
+  await refreshGrokState();
+}
+
+async function handleGrokStatus(_input: string, ctx: CommandContext): Promise<void> {
+  showStatus(ctx);
+}
+
+async function handleGrokLogout(_input: string, ctx: CommandContext): Promise<void> {
+  const theme = getThemeTokens();
+  deleteTokens();
+  await refreshGrokState();
+  const usingGrok = ctx.chat.activeModel.startsWith("grok/");
+  ctx.openInfoPopup({
+    title: "Grok Logout",
+    icon: providerIcon("grok"),
+    lines: getGrokLogoutPopupLines(
+      { ok: true, message: "Logged out of Grok (subscription)." },
+      usingGrok,
+      theme,
+    ),
+  });
+}
+
+async function handleGrokSwitch(_input: string, ctx: CommandContext): Promise<void> {
+  const theme = getThemeTokens();
+  deleteTokens();
+  await refreshGrokState();
+  ctx.openInfoPopup({
+    title: "Grok Switch Account",
+    icon: providerIcon("grok"),
+    lines: [
+      {
+        type: "text",
+        label: "Logged out of Grok. Starting login for another account...",
+        color: theme.textPrimary,
+      },
+    ],
+  });
+  await handleGrokLogin(_input, ctx);
+}
+
+export function register(map: Map<string, CommandHandler>): void {
+  map.set("/grok", handleGrokStatus);
+  map.set("/grok login", handleGrokLogin);
+  map.set("/grok status", handleGrokStatus);
+  map.set("/grok logout", handleGrokLogout);
+  map.set("/grok switch", handleGrokSwitch);
+}

--- a/src/core/commands/registry.ts
+++ b/src/core/commands/registry.ts
@@ -7,6 +7,7 @@ import { matchConfigPrefix, register as registerConfig } from "./config.js";
 import { matchContextPrefix, register as registerContext } from "./context.js";
 import { register as registerDebug } from "./debug.js";
 import { matchGitPrefix, register as registerGit } from "./git.js";
+import { register as registerGrok } from "./grok.js";
 import { register as registerHearth } from "./hearth.js";
 import { register as registerHooks } from "./hooks.js";
 import { matchNavPrefix, register as registerNavigation } from "./navigation.js";
@@ -31,6 +32,7 @@ registerStorage(commandMap);
 registerSecurity(commandMap);
 registerClaims(commandMap);
 registerCodex(commandMap);
+registerGrok(commandMap);
 registerHearth(commandMap);
 registerHooks(commandMap);
 registerCheckpoint(commandMap);
@@ -370,6 +372,41 @@ const COMMAND_DEFS: CommandDef[] = [
     desc: "Show Codex login status",
     category: "Models",
     tags: ["codex", "auth", "status", "account"],
+  },
+  {
+    cmd: "/grok",
+    ic: "model",
+    desc: "Show Grok (subscription) login status",
+    category: "Models",
+    tags: ["auth", "oauth", "grok", "xai", "status", "account"],
+  },
+  {
+    cmd: "/grok login",
+    ic: "model",
+    desc: "Log in to Grok with SuperGrok / X Premium+",
+    category: "Models",
+    tags: ["auth", "oauth", "grok", "xai", "login"],
+  },
+  {
+    cmd: "/grok logout",
+    ic: "model",
+    desc: "Log out of the Grok subscription session",
+    category: "Models",
+    tags: ["auth", "oauth", "grok", "xai", "logout", "account"],
+  },
+  {
+    cmd: "/grok switch",
+    ic: "model",
+    desc: "Switch to a different Grok account",
+    category: "Models",
+    tags: ["auth", "oauth", "grok", "xai", "switch", "account"],
+  },
+  {
+    cmd: "/grok status",
+    ic: "model",
+    desc: "Show Grok (subscription) login status",
+    category: "Models",
+    tags: ["auth", "oauth", "grok", "xai", "status", "account"],
   },
   {
     cmd: "/model-scope",

--- a/src/core/llm/provider-options.ts
+++ b/src/core/llm/provider-options.ts
@@ -140,6 +140,7 @@ const PROVIDER_CONSTRAINTS: Record<string, ProviderConstraints> = {
   proxy: GATEWAY_FULL,
   openai: OPENAI_FULL,
   xai: XAI_FULL,
+  grok: XAI_FULL,
   google: GOOGLE_FULL,
   deepseek: DEEPSEEK_FULL,
   openrouter: OPENROUTER_FULL,
@@ -220,7 +221,7 @@ export function detectModelFamily(modelId: string): ModelFamily {
   // Direct providers — no guessing needed
   if (provider === "anthropic") return "claude";
   if (provider === "openai") return "openai";
-  if (provider === "xai") return "xai";
+  if (provider === "xai" || provider === "grok") return "xai";
   if (provider === "google") return "google";
   if (provider === "deepseek") return isDeepSeekReasoner(base) ? "deepseek-reasoner" : "deepseek";
 

--- a/src/core/llm/providers/grok.ts
+++ b/src/core/llm/providers/grok.ts
@@ -1,0 +1,1 @@
+export * from "./grok/index.js";

--- a/src/core/llm/providers/grok/auth.ts
+++ b/src/core/llm/providers/grok/auth.ts
@@ -168,6 +168,11 @@ export async function requestGrokAuth(): Promise<void> {
     });
   } catch (error) {
     finished = true;
+    if (error instanceof Error && error.name === "AbortError") {
+      // User cancellation is already handled by the onClose abort; don't
+      // reopen the popup with an error message after the user pressed Esc.
+      return;
+    }
     const message = error instanceof Error ? error.message : String(error);
     lines.push(...wrapInfoText(`Error: ${message}`, theme.brandSecondary));
     updatePopup();

--- a/src/core/llm/providers/grok/auth.ts
+++ b/src/core/llm/providers/grok/auth.ts
@@ -1,0 +1,175 @@
+import type { InfoPopupLine } from "../../../../components/modals/InfoPopup.js";
+import { useUIStore } from "../../../../stores/ui.js";
+import { providerIcon } from "../../../icons.js";
+import { getThemeTokens } from "../../../theme/index.js";
+import { openPath } from "../../../utils/open-path.js";
+import { invalidateProviderModelCache } from "../../models.js";
+import { checkProviders } from "../../provider.js";
+import { loginWithDeviceCode } from "./device-code.js";
+import { isLoggedIn } from "./token-store.js";
+
+/** Popup width for Grok login — long URLs + region note need more than the 72 default. */
+const GROK_LOGIN_POPUP_WIDTH = 84;
+/** Soft wrap for InfoPopup text rows (InfoLine truncates; it does not wrap). */
+const GROK_LOGIN_LINE_WIDTH = 76;
+
+/** Word-wrap a string into InfoPopup text lines (InfoLine is single-row + truncate). */
+export function wrapInfoText(
+  text: string,
+  color: string,
+  maxWidth = GROK_LOGIN_LINE_WIDTH,
+): InfoPopupLine[] {
+  const words = text.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [];
+  const lines: InfoPopupLine[] = [];
+  let current = "";
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length <= maxWidth) {
+      current = next;
+      continue;
+    }
+    if (current) lines.push({ type: "text", label: current, color });
+    // Hard-split tokens longer than maxWidth (e.g. long URLs).
+    if (word.length > maxWidth) {
+      for (let i = 0; i < word.length; i += maxWidth) {
+        const chunk = word.slice(i, i + maxWidth);
+        if (i + maxWidth < word.length) {
+          lines.push({ type: "text", label: chunk, color });
+        } else {
+          current = chunk;
+        }
+      }
+    } else {
+      current = word;
+    }
+  }
+  if (current) lines.push({ type: "text", label: current, color });
+  return lines;
+}
+
+/** Success copy after device-code login. */
+export function getGrokLoginSuccessLines(
+  theme: ReturnType<typeof getThemeTokens>,
+): InfoPopupLine[] {
+  return [
+    {
+      type: "text",
+      label: "Logged in to Grok (subscription).",
+      color: theme.success,
+    },
+    {
+      type: "text",
+      label: "Press Esc to open the model picker, or use Ctrl+L / /models.",
+      color: theme.textPrimary,
+    },
+    { type: "spacer" },
+    ...wrapInfoText(
+      "Note: not all models are available in every region. A VPN (e.g. to the US) may be required for the newest subscription-only models.",
+      theme.textSecondary,
+    ),
+  ];
+}
+
+function openUrlInBrowser(url: string): boolean {
+  return openPath(url);
+}
+
+export function runGrokDeviceLogin(onEvent?: (message: string) => void): {
+  promise: Promise<void>;
+  abort: () => void;
+} {
+  const controller = new AbortController();
+
+  const promise = (async () => {
+    if (isLoggedIn()) {
+      onEvent?.("Already logged in to Grok (subscription).");
+      return;
+    }
+
+    await loginWithDeviceCode({
+      signal: controller.signal,
+      onStatus: (message) => onEvent?.(message),
+      onCode: ({ userCode, verificationUri, verificationUriComplete }) => {
+        const url = verificationUriComplete || verificationUri;
+        onEvent?.("Opening browser for Grok login...");
+        const opened = openUrlInBrowser(url);
+        if (opened) {
+          onEvent?.("Browser opened. Complete the login on the xAI / X page.");
+        } else {
+          onEvent?.("Could not open browser automatically. Open this URL manually:");
+          onEvent?.(url);
+        }
+        onEvent?.(`User code: ${userCode}`);
+        // Always surface the URL in the TUI so users can copy it if the wrong
+        // browser opened or the window was missed.
+        onEvent?.("URL:");
+        onEvent?.(url);
+      },
+    });
+  })();
+
+  return {
+    promise,
+    abort: () => controller.abort(),
+  };
+}
+
+export async function requestGrokAuth(): Promise<void> {
+  const theme = getThemeTokens();
+  const lines: InfoPopupLine[] = [
+    {
+      type: "text",
+      label: "Starting Grok (subscription) login...",
+      color: theme.textSecondary,
+    },
+  ];
+
+  let handle: ReturnType<typeof runGrokDeviceLogin> | null = null;
+  let finished = false;
+
+  const updatePopup = (onClose?: () => void) => {
+    useUIStore.getState().openInfoPopup({
+      title: "Grok Login",
+      icon: providerIcon("grok"),
+      width: GROK_LOGIN_POPUP_WIDTH,
+      lines: [...lines],
+      // During login, Esc aborts the poll. After success, Esc opens the model picker.
+      // openModal() resets ALL modals (including this popup), so we must not call it
+      // until the user dismisses — otherwise the success/region note never appears.
+      onClose:
+        onClose ??
+        (() => {
+          if (!finished) handle?.abort();
+        }),
+    });
+  };
+
+  updatePopup();
+  handle = runGrokDeviceLogin((message) => {
+    // Wrap long status lines (URLs) so InfoLine does not truncate them mid-string.
+    if (message.length > GROK_LOGIN_LINE_WIDTH || /^https?:\/\//.test(message)) {
+      lines.push(...wrapInfoText(message, theme.textPrimary));
+    } else {
+      lines.push({ type: "text", label: message, color: theme.textPrimary });
+    }
+    updatePopup();
+  });
+
+  try {
+    await handle.promise;
+    finished = true;
+    invalidateProviderModelCache("grok");
+    await checkProviders().catch(() => {});
+    lines.push({ type: "spacer" });
+    lines.push(...getGrokLoginSuccessLines(theme));
+    updatePopup(() => {
+      useUIStore.getState().openModal("llmSelector");
+    });
+  } catch (error) {
+    finished = true;
+    const message = error instanceof Error ? error.message : String(error);
+    lines.push(...wrapInfoText(`Error: ${message}`, theme.brandSecondary));
+    updatePopup();
+  }
+}

--- a/src/core/llm/providers/grok/constants.ts
+++ b/src/core/llm/providers/grok/constants.ts
@@ -1,0 +1,21 @@
+import { join } from "node:path";
+import { configDir } from "../../../platform/index.js";
+
+// Community OAuth client shared by progrok / Hermes / OpenClaw (MIT lineage).
+// Unofficial — not endorsed by xAI. Documented in mintlify-docs/providers/grok.mdx.
+export const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+export const XAI_OAUTH_SCOPE = "openid profile email offline_access grok-cli:access api:access";
+export const XAI_OAUTH_ISSUER = "https://auth.x.ai";
+export const XAI_OAUTH_DISCOVERY_URL = `${XAI_OAUTH_ISSUER}/.well-known/openid-configuration`;
+
+export const XAI_OAUTH_FETCH_TIMEOUT_MS = 30 * 1000;
+export const XAI_DEVICE_CODE_POLL_INTERVAL_MS = 5 * 1000;
+export const TOKEN_REFRESH_SKEW_MS = 2 * 60 * 1000;
+
+export const XAI_API_BASE_URL = "https://api.x.ai/v1";
+export const DEFAULT_MODEL = "grok-4.3";
+
+/** Token store path under SoulForge config dir (not ~/.progrok). */
+export function authFilePath(): string {
+  return join(configDir(), "xai-oauth.json");
+}

--- a/src/core/llm/providers/grok/device-code.ts
+++ b/src/core/llm/providers/grok/device-code.ts
@@ -1,0 +1,146 @@
+import {
+  XAI_DEVICE_CODE_POLL_INTERVAL_MS,
+  XAI_OAUTH_CLIENT_ID,
+  XAI_OAUTH_FETCH_TIMEOUT_MS,
+  XAI_OAUTH_SCOPE,
+} from "./constants.js";
+import { fetchOIDCDiscovery } from "./discovery.js";
+import { type OAuthTokenResponse, saveTokens } from "./token-store.js";
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  expires_in: number;
+  interval?: number;
+}
+
+export interface DeviceCodeStatus {
+  userCode: string;
+  verificationUri: string;
+  verificationUriComplete?: string;
+}
+
+export interface LoginWithDeviceCodeOptions {
+  onCode?: (info: DeviceCodeStatus) => void;
+  onStatus?: (message: string) => void;
+  signal?: AbortSignal;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error("Grok login cancelled."));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error("Grok login cancelled."));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export async function loginWithDeviceCode(options: LoginWithDeviceCodeOptions = {}): Promise<void> {
+  const { onCode, onStatus, signal } = options;
+
+  onStatus?.("Discovering xAI OAuth endpoints...");
+  const discovery = await fetchOIDCDiscovery();
+
+  if (!discovery.deviceAuthorizationEndpoint) {
+    throw new Error("xAI does not advertise device-code flow via OIDC discovery.");
+  }
+
+  if (signal?.aborted) throw new Error("Grok login cancelled.");
+
+  onStatus?.("Requesting device code...");
+  const dcRes = await fetch(discovery.deviceAuthorizationEndpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: XAI_OAUTH_CLIENT_ID,
+      scope: XAI_OAUTH_SCOPE,
+    }),
+    signal: signal ?? AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
+  });
+
+  if (!dcRes.ok) {
+    throw new Error(`Device code request failed: ${await dcRes.text()}`);
+  }
+
+  const dc = (await dcRes.json()) as DeviceCodeResponse;
+  const codeInfo = {
+    userCode: dc.user_code,
+    verificationUri: dc.verification_uri,
+    verificationUriComplete: dc.verification_uri_complete,
+  };
+  onCode?.(codeInfo);
+
+  // When no UI callback is wired (tests / headless), print the code ourselves.
+  if (!onCode) {
+    const completeUrl = dc.verification_uri_complete || dc.verification_uri;
+    onStatus?.(`Open: ${completeUrl}`);
+    onStatus?.(`Enter code: ${dc.user_code}`);
+  }
+  onStatus?.("Waiting for authorization...");
+
+  // Server-provided interval is authoritative; fall back to the default poll floor.
+  let intervalMs =
+    typeof dc.interval === "number" && dc.interval >= 0
+      ? Math.max(dc.interval * 1000, 0)
+      : XAI_DEVICE_CODE_POLL_INTERVAL_MS;
+  const deadline = Date.now() + dc.expires_in * 1000;
+
+  while (Date.now() < deadline) {
+    if (signal?.aborted) throw new Error("Grok login cancelled.");
+    if (intervalMs > 0) await sleep(intervalMs, signal);
+
+    const pollRes = await fetch(discovery.tokenEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        client_id: XAI_OAUTH_CLIENT_ID,
+        device_code: dc.device_code,
+      }),
+      signal: signal ?? AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
+    });
+
+    if (pollRes.ok) {
+      const tokens = (await pollRes.json()) as OAuthTokenResponse;
+      if (typeof tokens.access_token !== "string" || !tokens.access_token) {
+        throw new Error("Device code exchange returned an invalid access_token.");
+      }
+      saveTokens({
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token,
+        expiresIn: tokens.expires_in,
+        idToken: tokens.id_token,
+        tokenEndpoint: discovery.tokenEndpoint,
+      });
+      onStatus?.("Logged in to Grok successfully.");
+      return;
+    }
+
+    let err: { error?: string; error_description?: string };
+    try {
+      err = (await pollRes.json()) as { error?: string; error_description?: string };
+    } catch {
+      throw new Error(`Device code poll failed: HTTP ${String(pollRes.status)}`);
+    }
+
+    if (err.error === "authorization_pending") continue;
+    if (err.error === "slow_down") {
+      intervalMs += 5000;
+      continue;
+    }
+    throw new Error(`Device code poll failed: ${err.error_description || err.error || "unknown"}`);
+  }
+
+  throw new Error("Device code expired. Run /grok login again.");
+}

--- a/src/core/llm/providers/grok/device-code.ts
+++ b/src/core/llm/providers/grok/device-code.ts
@@ -108,7 +108,9 @@ export async function loginWithDeviceCode(options: LoginWithDeviceCodeOptions = 
         client_id: XAI_OAUTH_CLIENT_ID,
         device_code: dc.device_code,
       }),
-      signal: signal ?? AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS)])
+        : AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
     });
 
     if (pollRes.ok) {

--- a/src/core/llm/providers/grok/discovery.ts
+++ b/src/core/llm/providers/grok/discovery.ts
@@ -1,0 +1,69 @@
+import { XAI_OAUTH_DISCOVERY_URL, XAI_OAUTH_FETCH_TIMEOUT_MS } from "./constants.js";
+
+export interface OIDCDiscovery {
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  deviceAuthorizationEndpoint?: string;
+}
+
+let cached: { value: OIDCDiscovery; fetchedAt: number } | null = null;
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+function requireTrustedEndpoint(url: string, label: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") {
+      throw new Error("not HTTPS");
+    }
+    if (parsed.hostname !== "x.ai" && !parsed.hostname.endsWith(".x.ai")) {
+      throw new Error("not *.x.ai");
+    }
+    return url;
+  } catch {
+    throw new Error(`OIDC discovery returned untrusted ${label}: ${url}`);
+  }
+}
+
+/** Clear in-memory discovery cache (tests). */
+export function clearDiscoveryCache(): void {
+  cached = null;
+}
+
+export async function fetchOIDCDiscovery(): Promise<OIDCDiscovery> {
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.value;
+  }
+
+  const res = await fetch(XAI_OAUTH_DISCOVERY_URL, {
+    signal: AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
+  });
+
+  if (!res.ok) {
+    throw new Error(`OIDC discovery failed: HTTP ${String(res.status)}`);
+  }
+
+  interface OIDCRawResponse {
+    authorization_endpoint: string;
+    token_endpoint: string;
+    device_authorization_endpoint?: string;
+  }
+
+  const data = (await res.json()) as OIDCRawResponse;
+
+  const authorizationEndpoint = requireTrustedEndpoint(
+    data.authorization_endpoint,
+    "authorization_endpoint",
+  );
+  const tokenEndpoint = requireTrustedEndpoint(data.token_endpoint, "token_endpoint");
+  const deviceAuthorizationEndpoint = data.device_authorization_endpoint
+    ? requireTrustedEndpoint(data.device_authorization_endpoint, "device_authorization_endpoint")
+    : undefined;
+
+  const value: OIDCDiscovery = {
+    authorizationEndpoint,
+    tokenEndpoint,
+    deviceAuthorizationEndpoint,
+  };
+  cached = { value, fetchedAt: Date.now() };
+  return value;
+}

--- a/src/core/llm/providers/grok/index.ts
+++ b/src/core/llm/providers/grok/index.ts
@@ -1,0 +1,111 @@
+import { createXai } from "@ai-sdk/xai";
+import type { LanguageModel } from "ai";
+import { createSessionFetchWrapper, type ReasoningFetchFn } from "../reasoning-fetch.js";
+import type { ProviderDefinition, ProviderModelInfo } from "../types.js";
+import { XAI_API_BASE_URL } from "./constants.js";
+import { getValidBearer, isLoggedIn } from "./token-store.js";
+
+interface XaiModel {
+  id: string;
+  context_window?: number;
+}
+
+function createGrokOAuthFetch(): ReasoningFetchFn {
+  return createSessionFetchWrapper({}, async (input, init) => {
+    const token = await getValidBearer();
+    const headers = new Headers(init?.headers);
+    headers.set("Authorization", `Bearer ${token}`);
+    return fetch(input, { ...init, headers });
+  });
+}
+
+function createGrokModel(modelId: string): LanguageModel {
+  if (!isLoggedIn()) {
+    throw new Error("Not logged in to Grok. Run /grok login or press Enter in the model picker.");
+  }
+  // createXai is sync; refresh lives in the fetch wrapper so every request gets a valid bearer.
+  return createXai({
+    apiKey: "oauth",
+    fetch: createGrokOAuthFetch() as typeof fetch,
+  })(modelId);
+}
+
+export const GROK_FALLBACK_MODELS: ProviderModelInfo[] = [
+  { id: "grok-4.3", name: "Grok 4.3" },
+  { id: "grok-4.20", name: "Grok 4.20" },
+  { id: "grok-4.1-fast", name: "Grok 4.1 Fast" },
+  { id: "grok-4-fast", name: "Grok 4 Fast" },
+  { id: "grok-4", name: "Grok 4" },
+  { id: "grok-code-fast-1", name: "Grok Code Fast 1" },
+  { id: "grok-3", name: "Grok 3" },
+  { id: "grok-3-mini", name: "Grok 3 Mini" },
+];
+
+export const GROK_CONTEXT_WINDOWS: [pattern: string, tokens: number][] = [
+  ["grok-4.3", 2_000_000],
+  ["grok-4.20", 2_000_000],
+  ["grok-4.1-fast", 2_000_000],
+  ["grok-4-fast", 2_000_000],
+  ["grok-code-fast-1", 256_000],
+  ["grok-4.1", 2_000_000],
+  ["grok-4", 256_000],
+  ["grok-3", 131_072],
+  ["grok-2", 131_072],
+  ["grok", 131_072],
+];
+
+export const grok: ProviderDefinition = {
+  id: "grok",
+  name: "Grok (subscription)",
+  // Empty envVar keeps this out of getProviderSecretEntries() (OAuth, not API key).
+  envVar: "",
+  icon: "\uF0E7", // nf-fa-bolt — same as xai
+  asciiIcon: "G",
+  description: "SuperGrok via xAI OAuth",
+  badge: "subscription",
+  noAuthLabel: "login required — Enter to authenticate",
+  authErrorLabel: "login/session error",
+  onRequestAuth: async () => {
+    const { requestGrokAuth } = await import("./auth.js");
+    await requestGrokAuth();
+  },
+  createModel: createGrokModel,
+  async fetchModels(): Promise<ProviderModelInfo[] | null> {
+    if (!isLoggedIn()) return null;
+    try {
+      const token = await getValidBearer();
+      const res = await fetch(`${XAI_API_BASE_URL}/models`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) throw new Error(`xAI API ${String(res.status)}`);
+      const data = (await res.json()) as { data: XaiModel[] };
+      const result: ProviderModelInfo[] = [];
+      for (const m of data.data) {
+        if (!m.id.includes("embed")) {
+          result.push({ id: m.id, name: m.id, contextWindow: m.context_window });
+        }
+      }
+      return result;
+    } catch {
+      return null;
+    }
+  },
+  fallbackModels: GROK_FALLBACK_MODELS,
+  contextWindows: GROK_CONTEXT_WINDOWS,
+  checkAvailability: async () => isLoggedIn(),
+};
+
+export { loginWithDeviceCode } from "./device-code.js";
+export { clearDiscoveryCache, fetchOIDCDiscovery } from "./discovery.js";
+export {
+  deleteTokens,
+  getLoginStatus,
+  getValidBearer,
+  isLoggedIn,
+  loadTokens,
+  saveTokens,
+} from "./token-store.js";
+// auth.ts is intentionally not re-exported here — it imports models/UI and would
+// create a circular init cycle with providers/index.ts. Use dynamic import or
+// import from "./grok/auth.js" directly.

--- a/src/core/llm/providers/grok/index.ts
+++ b/src/core/llm/providers/grok/index.ts
@@ -7,7 +7,7 @@ import { getValidBearer, isLoggedIn } from "./token-store.js";
 
 interface XaiModel {
   id: string;
-  context_window?: number;
+  context_length?: number;
 }
 
 function createGrokOAuthFetch(): ReasoningFetchFn {
@@ -83,7 +83,7 @@ export const grok: ProviderDefinition = {
       const result: ProviderModelInfo[] = [];
       for (const m of data.data) {
         if (!m.id.includes("embed")) {
-          result.push({ id: m.id, name: m.id, contextWindow: m.context_window });
+          result.push({ id: m.id, name: m.id, contextWindow: m.context_length });
         }
       }
       return result;

--- a/src/core/llm/providers/grok/token-store.ts
+++ b/src/core/llm/providers/grok/token-store.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import {
   authFilePath,
@@ -58,13 +58,14 @@ export function saveTokens(input: SaveTokenInput): void {
   const data: TokenData = {
     accessToken: input.accessToken,
     refreshToken: input.refreshToken ?? existing?.refreshToken,
-    expiresAt: input.expiresIn ? Date.now() + input.expiresIn * 1000 : existing?.expiresAt,
+    expiresAt: input.expiresIn !== undefined ? Date.now() + input.expiresIn * 1000 : undefined,
     tokenEndpoint: input.tokenEndpoint ?? existing?.tokenEndpoint,
     idToken: input.idToken ?? existing?.idToken,
     email: input.email ?? extractEmailFromIdToken(input.idToken) ?? existing?.email,
   };
 
   writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
+  chmodSync(path, 0o600);
 }
 
 export function loadTokens(): TokenData | null {
@@ -81,8 +82,9 @@ export function loadTokens(): TokenData | null {
 export function deleteTokens(): void {
   try {
     unlinkSync(authFilePath());
-  } catch {
-    /* ignore missing file */
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+    throw error;
   }
 }
 
@@ -126,6 +128,9 @@ export async function getValidBearer(): Promise<string> {
 
   if (refreshInflight) return refreshInflight;
 
+  const initialAccessToken = tokens.accessToken;
+  const initialRefreshToken = refreshToken;
+
   refreshInflight = (async () => {
     try {
       const res = await fetch(tokenEndpoint, {
@@ -150,15 +155,21 @@ export async function getValidBearer(): Promise<string> {
         );
       }
 
-      saveTokens({
-        accessToken: refreshed.access_token,
-        refreshToken:
-          typeof refreshed.refresh_token === "string" ? refreshed.refresh_token : refreshToken,
-        expiresIn: typeof refreshed.expires_in === "number" ? refreshed.expires_in : undefined,
-        idToken: typeof refreshed.id_token === "string" ? refreshed.id_token : undefined,
-        tokenEndpoint,
-        email: tokens.email,
-      });
+      const current = loadTokens();
+      const sessionStillMatches =
+        current?.accessToken === initialAccessToken &&
+        current?.refreshToken === initialRefreshToken;
+      if (sessionStillMatches) {
+        saveTokens({
+          accessToken: refreshed.access_token,
+          refreshToken:
+            typeof refreshed.refresh_token === "string" ? refreshed.refresh_token : refreshToken,
+          expiresIn: typeof refreshed.expires_in === "number" ? refreshed.expires_in : undefined,
+          idToken: typeof refreshed.id_token === "string" ? refreshed.id_token : undefined,
+          tokenEndpoint,
+          email: tokens.email,
+        });
+      }
 
       return refreshed.access_token;
     } finally {

--- a/src/core/llm/providers/grok/token-store.ts
+++ b/src/core/llm/providers/grok/token-store.ts
@@ -1,0 +1,170 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+  authFilePath,
+  TOKEN_REFRESH_SKEW_MS,
+  XAI_OAUTH_CLIENT_ID,
+  XAI_OAUTH_FETCH_TIMEOUT_MS,
+} from "./constants.js";
+
+export interface TokenData {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  tokenEndpoint?: string;
+  email?: string;
+  idToken?: string;
+}
+
+export interface SaveTokenInput {
+  accessToken: string;
+  refreshToken?: string;
+  expiresIn?: number;
+  idToken?: string;
+  tokenEndpoint?: string;
+  email?: string;
+}
+
+/** Shape returned by xAI OAuth token endpoint (exchange + refresh). */
+export interface OAuthTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  id_token?: string;
+  token_type?: string;
+}
+
+function extractEmailFromIdToken(idToken: string | undefined): string | undefined {
+  if (!idToken) return undefined;
+  try {
+    const parts = idToken.split(".");
+    if (!parts[1]) return undefined;
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString()) as Record<
+      string,
+      unknown
+    >;
+    return typeof payload.email === "string" ? payload.email : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveTokens(input: SaveTokenInput): void {
+  const path = authFilePath();
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  const existing = loadTokens();
+  const data: TokenData = {
+    accessToken: input.accessToken,
+    refreshToken: input.refreshToken ?? existing?.refreshToken,
+    expiresAt: input.expiresIn ? Date.now() + input.expiresIn * 1000 : existing?.expiresAt,
+    tokenEndpoint: input.tokenEndpoint ?? existing?.tokenEndpoint,
+    idToken: input.idToken ?? existing?.idToken,
+    email: input.email ?? extractEmailFromIdToken(input.idToken) ?? existing?.email,
+  };
+
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
+}
+
+export function loadTokens(): TokenData | null {
+  try {
+    const raw = readFileSync(authFilePath(), "utf8");
+    const data = JSON.parse(raw) as TokenData;
+    if (!data?.accessToken || typeof data.accessToken !== "string") return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export function deleteTokens(): void {
+  try {
+    unlinkSync(authFilePath());
+  } catch {
+    /* ignore missing file */
+  }
+}
+
+export function isLoggedIn(): boolean {
+  return !!loadTokens()?.accessToken;
+}
+
+export function getLoginStatus(): {
+  loggedIn: boolean;
+  email?: string;
+  expiresAt?: number;
+} {
+  const tokens = loadTokens();
+  if (!tokens?.accessToken) return { loggedIn: false };
+  return {
+    loggedIn: true,
+    email: tokens.email,
+    expiresAt: tokens.expiresAt,
+  };
+}
+
+let refreshInflight: Promise<string> | null = null;
+
+export async function getValidBearer(): Promise<string> {
+  const tokens = loadTokens();
+  if (!tokens?.accessToken) {
+    throw new Error("Not logged in to Grok. Run /grok login first.");
+  }
+
+  const needsRefresh = !!tokens.expiresAt && Date.now() + TOKEN_REFRESH_SKEW_MS >= tokens.expiresAt;
+
+  if (!needsRefresh) return tokens.accessToken;
+
+  const refreshToken = tokens.refreshToken;
+  const tokenEndpoint = tokens.tokenEndpoint;
+  if (!refreshToken || !tokenEndpoint) {
+    throw new Error(
+      "Grok session expired and no refresh token is available. Run /grok login again.",
+    );
+  }
+
+  if (refreshInflight) return refreshInflight;
+
+  refreshInflight = (async () => {
+    try {
+      const res = await fetch(tokenEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          client_id: XAI_OAUTH_CLIENT_ID,
+          refresh_token: refreshToken,
+        }),
+        signal: AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
+      });
+
+      if (!res.ok) {
+        throw new Error("Grok token refresh failed. Run /grok login again.");
+      }
+
+      const refreshed = (await res.json()) as OAuthTokenResponse;
+      if (typeof refreshed.access_token !== "string" || !refreshed.access_token) {
+        throw new Error(
+          "Grok token refresh returned an invalid access_token. Run /grok login again.",
+        );
+      }
+
+      saveTokens({
+        accessToken: refreshed.access_token,
+        refreshToken:
+          typeof refreshed.refresh_token === "string" ? refreshed.refresh_token : refreshToken,
+        expiresIn: typeof refreshed.expires_in === "number" ? refreshed.expires_in : undefined,
+        idToken: typeof refreshed.id_token === "string" ? refreshed.id_token : undefined,
+        tokenEndpoint,
+        email: tokens.email,
+      });
+
+      return refreshed.access_token;
+    } finally {
+      refreshInflight = null;
+    }
+  })();
+
+  return refreshInflight;
+}

--- a/src/core/llm/providers/index.ts
+++ b/src/core/llm/providers/index.ts
@@ -7,6 +7,7 @@ export { deepseek } from "./deepseek.js";
 export { fireworks } from "./fireworks.js";
 export { githubModels } from "./github-models.js";
 export { google } from "./google.js";
+export { grok } from "./grok.js";
 export { groq } from "./groq.js";
 export { llmgateway } from "./llmgateway.js";
 export { lmstudio } from "./lmstudio.js";
@@ -32,6 +33,7 @@ import { deepseek } from "./deepseek.js";
 import { fireworks } from "./fireworks.js";
 import { githubModels } from "./github-models.js";
 import { google } from "./google.js";
+import { grok } from "./grok.js";
 import { groq } from "./groq.js";
 import { llmgateway } from "./llmgateway.js";
 import { lmstudio } from "./lmstudio.js";
@@ -55,6 +57,7 @@ const BUILTIN_PROVIDERS: ProviderDefinition[] = [
   vercelGatewayProvider,
   openai,
   xai,
+  grok,
   google,
   groq,
   deepseek,

--- a/src/core/utils/open-path.ts
+++ b/src/core/utils/open-path.ts
@@ -35,10 +35,11 @@ export function openPath(pathOrUrl: string): boolean {
     // Supports bare commands ("brave") and %s templates ("brave %s").
     const browser = process.env.BROWSER?.trim();
     if (browser) {
-      const parts = browser.split(/\s+/).filter(Boolean);
-      if (parts.length > 0) {
-        const args = parts.map((p) => (p === "%s" ? pathOrUrl : p));
-        if (!parts.includes("%s")) args.push(pathOrUrl);
+      const words = parseShellWords(browser);
+      if (words.length > 0) {
+        const hasPlaceholder = words.some((w) => w.includes("%s"));
+        const args = words.map((w) => (hasPlaceholder ? w.replaceAll("%s", pathOrUrl) : w));
+        if (!hasPlaceholder) args.push(pathOrUrl);
         const cmd = args[0];
         if (cmd) {
           Bun.spawn([cmd, ...args.slice(1)], { stdio: ["ignore", "ignore", "ignore"] });
@@ -51,4 +52,45 @@ export function openPath(pathOrUrl: string): boolean {
   } catch {
     return false;
   }
+}
+function parseShellWords(input: string): string[] {
+  const words: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+  let escaped = false;
+
+  for (const ch of input) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current) {
+        words.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+
+  if (current) words.push(current);
+  return words;
 }

--- a/src/core/utils/open-path.ts
+++ b/src/core/utils/open-path.ts
@@ -15,7 +15,7 @@ import { IS_DARWIN, IS_WIN } from "../platform/index.js";
 export function openPath(pathOrUrl: string): boolean {
   try {
     if (IS_WIN) {
-      // `cmd /c start` interprets `&`, `^`, `%`, `|`, `\"` in the URL as
+      // `cmd /c start` interprets `&`, `^`, `%`, `|`, `"` in the URL as
       // shell metacharacters, opening the user up to argument injection if
       // pathOrUrl came from untrusted input (LLM-generated link, pasted
       // text). Reject any URL containing those before invoking cmd.exe.
@@ -26,8 +26,27 @@ export function openPath(pathOrUrl: string): boolean {
       });
       return true;
     }
-    const cmd = IS_DARWIN ? "open" : "xdg-open";
-    Bun.spawn([cmd, pathOrUrl], { stdio: ["ignore", "ignore", "ignore"] });
+    if (IS_DARWIN) {
+      Bun.spawn(["open", pathOrUrl], { stdio: ["ignore", "ignore", "ignore"] });
+      return true;
+    }
+    // Linux: honor $BROWSER when set (isolated HOME / containers often lose
+    // mimeapps.list, so xdg-open falls back to Firefox instead of Brave/Chrome).
+    // Supports bare commands ("brave") and %s templates ("brave %s").
+    const browser = process.env.BROWSER?.trim();
+    if (browser) {
+      const parts = browser.split(/\s+/).filter(Boolean);
+      if (parts.length > 0) {
+        const args = parts.map((p) => (p === "%s" ? pathOrUrl : p));
+        if (!parts.includes("%s")) args.push(pathOrUrl);
+        const cmd = args[0];
+        if (cmd) {
+          Bun.spawn([cmd, ...args.slice(1)], { stdio: ["ignore", "ignore", "ignore"] });
+          return true;
+        }
+      }
+    }
+    Bun.spawn(["xdg-open", pathOrUrl], { stdio: ["ignore", "ignore", "ignore"] });
     return true;
   } catch {
     return false;

--- a/tests/codex-provider.test.ts
+++ b/tests/codex-provider.test.ts
@@ -23,7 +23,7 @@ const BASE_OPTIONS: LanguageModelV2CallOptions = {
 describe("codex provider", () => {
   test("is registered as a builtin provider", () => {
     expect(getProvider("codex")).toBeDefined();
-    expect(getAllProviders().filter((provider) => !provider.custom)).toHaveLength(22);
+    expect(getAllProviders().filter((provider) => !provider.custom)).toHaveLength(23);
   });
 
   test("has provider metadata, fallback models, and shared auth hook", () => {

--- a/tests/grok-oauth.test.ts
+++ b/tests/grok-oauth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -24,6 +24,7 @@ import {
   loginWithDeviceCode,
   saveTokens,
 } from "../src/core/llm/providers/grok.js";
+import { CommandHandler } from "../src/core/commands/types.js";
 
 const originalFetch = globalThis.fetch;
 const originalHome = process.env.HOME;
@@ -119,6 +120,7 @@ describe("grok token store", () => {
     const path = join(tempHome, ".soulforge", "xai-oauth.json");
     const raw = readFileSync(path, "utf8");
     expect(raw).toContain("access-1");
+    expect(statSync(path).mode & 0o777).toBe(0o600);
 
     deleteTokens();
     expect(loadTokens()).toBeNull();
@@ -326,7 +328,7 @@ describe("grok availability + models", () => {
 
 describe("grok commands", () => {
   test("registers status, login, logout, and switch commands", () => {
-    const map = new Map();
+    const map = new Map<string, CommandHandler>();
     register(map);
     expect(map.has("/grok")).toBe(true);
     expect(map.has("/grok status")).toBe(true);

--- a/tests/grok-oauth.test.ts
+++ b/tests/grok-oauth.test.ts
@@ -1,0 +1,402 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  getGrokLogoutPopupLines,
+  getGrokStatusPopupLines,
+  register,
+} from "../src/core/commands/grok.js";
+import {
+  getGrokLoginSuccessLines,
+  wrapInfoText,
+} from "../src/core/llm/providers/grok/auth.js";
+import { getAllProviders, getProvider } from "../src/core/llm/providers/index.js";
+import {
+  clearDiscoveryCache,
+  deleteTokens,
+  fetchOIDCDiscovery,
+  getLoginStatus,
+  getValidBearer,
+  grok,
+  isLoggedIn,
+  loadTokens,
+  loginWithDeviceCode,
+  saveTokens,
+} from "../src/core/llm/providers/grok.js";
+
+const originalFetch = globalThis.fetch;
+const originalHome = process.env.HOME;
+const originalLocalAppData = process.env.LOCALAPPDATA;
+
+let tempHome: string;
+
+function setIsolatedConfigHome(): void {
+  tempHome = mkdtempSync(join(tmpdir(), "soulforge-grok-oauth-"));
+  process.env.HOME = tempHome;
+  delete process.env.LOCALAPPDATA;
+  mkdirSync(join(tempHome, ".soulforge"), { recursive: true, mode: 0o700 });
+}
+
+function restoreEnv(): void {
+  globalThis.fetch = originalFetch;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+  else process.env.LOCALAPPDATA = originalLocalAppData;
+  clearDiscoveryCache();
+  if (tempHome) rmSync(tempHome, { recursive: true, force: true });
+}
+
+const theme = {
+  success: "green",
+  brandSecondary: "red",
+  warning: "yellow",
+  textPrimary: "white",
+  textSecondary: "gray",
+} as const;
+
+describe("grok provider registration", () => {
+  test("is registered as a builtin provider", () => {
+    expect(getProvider("grok")).toBeDefined();
+    expect(getAllProviders().filter((provider) => !provider.custom)).toHaveLength(23);
+  });
+
+  test("has subscription metadata and auth hooks", () => {
+    expect(grok.id).toBe("grok");
+    expect(grok.name).toBe("Grok (subscription)");
+    expect(grok.envVar).toBe("");
+    expect(grok.badge).toBe("subscription");
+    expect(grok.noAuthLabel).toBe("login required — Enter to authenticate");
+    expect(grok.authErrorLabel).toBe("login/session error");
+    expect(grok.onRequestAuth).toBeDefined();
+    expect(grok.checkAvailability).toBeDefined();
+    expect(grok.fallbackModels.some((m) => m.id === "grok-4.3")).toBe(true);
+  });
+
+  test("createModel without tokens throws cleanly", () => {
+    setIsolatedConfigHome();
+    try {
+      expect(() => grok.createModel("grok-4.3")).toThrow(/\/grok login/);
+    } finally {
+      restoreEnv();
+    }
+  });
+});
+
+describe("grok token store", () => {
+  beforeEach(() => {
+    setIsolatedConfigHome();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  test("save/load/delete tokens", () => {
+    expect(isLoggedIn()).toBe(false);
+    saveTokens({
+      accessToken: "access-1",
+      refreshToken: "refresh-1",
+      expiresIn: 3600,
+      tokenEndpoint: "https://auth.x.ai/oauth/token",
+      idToken: [
+        "eyJhbGciOiJub25lIn0",
+        Buffer.from(JSON.stringify({ email: "user@example.com" })).toString("base64url"),
+        "sig",
+      ].join("."),
+    });
+
+    const loaded = loadTokens();
+    expect(loaded?.accessToken).toBe("access-1");
+    expect(loaded?.refreshToken).toBe("refresh-1");
+    expect(loaded?.email).toBe("user@example.com");
+    expect(loaded?.tokenEndpoint).toBe("https://auth.x.ai/oauth/token");
+    expect(typeof loaded?.expiresAt).toBe("number");
+    expect(isLoggedIn()).toBe(true);
+    expect(getLoginStatus()).toMatchObject({ loggedIn: true, email: "user@example.com" });
+
+    const path = join(tempHome, ".soulforge", "xai-oauth.json");
+    const raw = readFileSync(path, "utf8");
+    expect(raw).toContain("access-1");
+
+    deleteTokens();
+    expect(loadTokens()).toBeNull();
+    expect(isLoggedIn()).toBe(false);
+  });
+
+  test("getValidBearer returns non-expired token without refresh", async () => {
+    saveTokens({
+      accessToken: "still-good",
+      refreshToken: "refresh-1",
+      expiresIn: 3600,
+      tokenEndpoint: "https://auth.x.ai/oauth/token",
+    });
+    const calls: string[] = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      throw new Error("should not refresh");
+    }) as typeof fetch;
+
+    await expect(getValidBearer()).resolves.toBe("still-good");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("getValidBearer refreshes near-expiry tokens and persists", async () => {
+    saveTokens({
+      accessToken: "old-access",
+      refreshToken: "refresh-1",
+      expiresIn: 30, // within 2-minute skew
+      tokenEndpoint: "https://auth.x.ai/oauth/token",
+    });
+
+    globalThis.fetch = mock(async () =>
+      Response.json({
+        access_token: "new-access",
+        refresh_token: "refresh-2",
+        expires_in: 3600,
+      }),
+    ) as typeof fetch;
+
+    await expect(getValidBearer()).resolves.toBe("new-access");
+    expect(loadTokens()?.accessToken).toBe("new-access");
+    expect(loadTokens()?.refreshToken).toBe("refresh-2");
+  });
+
+  test("getValidBearer throws actionable error when refresh fails", async () => {
+    saveTokens({
+      accessToken: "old-access",
+      refreshToken: "refresh-1",
+      expiresIn: 30,
+      tokenEndpoint: "https://auth.x.ai/oauth/token",
+    });
+
+    globalThis.fetch = mock(async () => new Response("nope", { status: 401 })) as typeof fetch;
+
+    await expect(getValidBearer()).rejects.toThrow(/\/grok login/);
+  });
+
+  test("expired without refresh path throws", async () => {
+    const path = join(tempHome, ".soulforge", "xai-oauth.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        accessToken: "stale",
+        expiresAt: Date.now() - 1000,
+      }),
+      { mode: 0o600 },
+    );
+
+    await expect(getValidBearer()).rejects.toThrow(/refresh token/);
+  });
+});
+
+describe("grok discovery + device-code", () => {
+  beforeEach(() => {
+    setIsolatedConfigHome();
+    clearDiscoveryCache();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  test("fetchOIDCDiscovery maps endpoints and caches", async () => {
+    let hits = 0;
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      hits += 1;
+      expect(String(input)).toContain("openid-configuration");
+      return Response.json({
+        authorization_endpoint: "https://auth.x.ai/oauth/authorize",
+        token_endpoint: "https://auth.x.ai/oauth/token",
+        device_authorization_endpoint: "https://auth.x.ai/oauth/device",
+      });
+    }) as typeof fetch;
+
+    const first = await fetchOIDCDiscovery();
+    const second = await fetchOIDCDiscovery();
+    expect(first.tokenEndpoint).toBe("https://auth.x.ai/oauth/token");
+    expect(first.deviceAuthorizationEndpoint).toBe("https://auth.x.ai/oauth/device");
+    expect(second).toEqual(first);
+    expect(hits).toBe(1);
+  });
+
+  test("fetchOIDCDiscovery rejects untrusted hosts", async () => {
+    globalThis.fetch = mock(async () =>
+      Response.json({
+        authorization_endpoint: "https://evil.example/oauth/authorize",
+        token_endpoint: "https://evil.example/oauth/token",
+      }),
+    ) as typeof fetch;
+
+    await expect(fetchOIDCDiscovery()).rejects.toThrow(/untrusted/);
+  });
+
+  test("device-code poll: pending then success", async () => {
+    const events: string[] = [];
+    let poll = 0;
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("openid-configuration")) {
+        return Response.json({
+          authorization_endpoint: "https://auth.x.ai/oauth/authorize",
+          token_endpoint: "https://auth.x.ai/oauth/token",
+          device_authorization_endpoint: "https://auth.x.ai/oauth/device",
+        });
+      }
+      if (url.includes("/oauth/device") && init?.method === "POST") {
+        return Response.json({
+          device_code: "dev-1",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://auth.x.ai/device",
+          verification_uri_complete: "https://auth.x.ai/device?user_code=ABCD-EFGH",
+          expires_in: 600,
+          interval: 0,
+        });
+      }
+      if (url.includes("/oauth/token")) {
+        poll += 1;
+        if (poll === 1) {
+          return Response.json({ error: "authorization_pending" }, { status: 400 });
+        }
+        return Response.json({
+          access_token: "device-access",
+          refresh_token: "device-refresh",
+          expires_in: 3600,
+          id_token: [
+            "eyJhbGciOiJub25lIn0",
+            Buffer.from(JSON.stringify({ email: "device@example.com" })).toString("base64url"),
+            "sig",
+          ].join("."),
+        });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }) as typeof fetch;
+
+    await loginWithDeviceCode({
+      onStatus: (m) => events.push(m),
+      onCode: (info) => {
+        expect(info.userCode).toBe("ABCD-EFGH");
+      },
+    });
+
+    expect(isLoggedIn()).toBe(true);
+    expect(loadTokens()?.accessToken).toBe("device-access");
+    expect(loadTokens()?.email).toBe("device@example.com");
+    expect(events.some((e) => e.includes("Logged in"))).toBe(true);
+  });
+});
+
+describe("grok availability + models", () => {
+  beforeEach(() => {
+    setIsolatedConfigHome();
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  test("checkAvailability true/false", async () => {
+    expect(await grok.checkAvailability?.()).toBe(false);
+    saveTokens({ accessToken: "a", expiresIn: 3600, tokenEndpoint: "https://auth.x.ai/oauth/token" });
+    expect(await grok.checkAvailability?.()).toBe(true);
+  });
+
+  test("fetchModels filters embed ids", async () => {
+    saveTokens({
+      accessToken: "a",
+      expiresIn: 3600,
+      tokenEndpoint: "https://auth.x.ai/oauth/token",
+    });
+    globalThis.fetch = mock(async () =>
+      Response.json({
+        data: [
+          { id: "grok-4.3", context_window: 2_000_000 },
+          { id: "text-embedding-3", context_window: 8192 },
+          { id: "grok-3", context_window: 131_072 },
+        ],
+      }),
+    ) as typeof fetch;
+
+    const models = await grok.fetchModels();
+    expect(models?.map((m) => m.id)).toEqual(["grok-4.3", "grok-3"]);
+  });
+});
+
+describe("grok commands", () => {
+  test("registers status, login, logout, and switch commands", () => {
+    const map = new Map();
+    register(map);
+    expect(map.has("/grok")).toBe(true);
+    expect(map.has("/grok status")).toBe(true);
+    expect(map.has("/grok login")).toBe(true);
+    expect(map.has("/grok logout")).toBe(true);
+    expect(map.has("/grok switch")).toBe(true);
+  });
+
+  test("builds status popup lines", () => {
+    const lines = getGrokStatusPopupLines(
+      { loggedIn: false },
+      theme as ReturnType<typeof import("../src/core/theme/index.js").getThemeTokens>,
+    );
+    expect(lines[0]).toMatchObject({ type: "entry", label: "Logged in", desc: "no" });
+  });
+
+  test("builds logout popup lines with active-model warning", () => {
+    const lines = getGrokLogoutPopupLines(
+      { ok: true, message: "Logged out of Grok (subscription)." },
+      true,
+      theme as ReturnType<typeof import("../src/core/theme/index.js").getThemeTokens>,
+    );
+    expect(lines[0]).toMatchObject({
+      type: "text",
+      label: "Logged out of Grok (subscription).",
+    });
+    expect(lines[2]).toMatchObject({
+      type: "text",
+      label:
+        "The active model is still Grok (subscription). Switch models or log back in before your next prompt.",
+    });
+  });
+
+  test("success lines mention login, model picker, and regional VPN note", () => {
+    const lines = getGrokLoginSuccessLines(
+      theme as ReturnType<typeof import("../src/core/theme/index.js").getThemeTokens>,
+    );
+    expect(lines[0]).toMatchObject({
+      type: "text",
+      label: "Logged in to Grok (subscription).",
+    });
+    expect(
+      lines.some((l) => l.type === "text" && /Ctrl\+L|model picker|\/models/i.test(l.label ?? "")),
+    ).toBe(true);
+    const regionText = lines
+      .filter((l) => l.type === "text")
+      .map((l) => l.label ?? "")
+      .join(" ");
+    expect(regionText).toMatch(/VPN/i);
+    expect(regionText).toMatch(/region/i);
+    expect(regionText).toMatch(/subscription-only models/i);
+    // No single line should exceed the wrap width used by the login popup.
+    for (const l of lines) {
+      if (l.type === "text" && l.label) expect(l.label.length).toBeLessThanOrEqual(76);
+    }
+  });
+
+  test("wrapInfoText splits long notes and hard-wraps URLs", () => {
+    const note = wrapInfoText(
+      "Note: not all models are available in every region. A VPN (e.g. to the US) may be required for the newest subscription-only models.",
+      "gray",
+      40,
+    );
+    expect(note.length).toBeGreaterThan(1);
+    expect(note.every((l) => (l.label?.length ?? 0) <= 40)).toBe(true);
+
+    const url =
+      "https://accounts.x.ai/oauth2/device?user_code=K9DA-66NC&extra=padding-to-force-hard-wrap-aaaaaaaa";
+    const urlLines = wrapInfoText(url, "white", 40);
+    expect(urlLines.length).toBeGreaterThan(1);
+    expect(urlLines.map((l) => l.label).join("")).toBe(url);
+  });
+});

--- a/tests/local-providers.test.ts
+++ b/tests/local-providers.test.ts
@@ -14,9 +14,9 @@ describe("local providers registration", () => {
 		expect(getProvider("lmstudio")!.custom).toBeUndefined();
 	});
 
-	test("total builtin count is 22", () => {
+	test("total builtin count is 23", () => {
 		const builtins = getAllProviders().filter((p) => !p.custom);
-		expect(builtins.length).toBe(22);
+		expect(builtins.length).toBe(23);
 	});
 
 	test("ollama has required fields", () => {

--- a/tests/new-providers.test.ts
+++ b/tests/new-providers.test.ts
@@ -37,8 +37,8 @@ describe("new providers registration", () => {
 
 	test("total builtin count increased by 5", () => {
 		const builtins = getAllProviders().filter((p) => !p.custom);
-		// Was 13, then 18 after the previous provider batch, now 22 with Codex + OpenCode + NIM.
-		expect(builtins.length).toBe(22);
+		// Was 13, then 18 after the previous provider batch, 22 with Codex + OpenCode + NIM, 23 with Grok OAuth.
+		expect(builtins.length).toBe(23);
 	});
 });
 

--- a/tests/provider-options.test.ts
+++ b/tests/provider-options.test.ts
@@ -185,6 +185,10 @@ describe("detectModelFamily", () => {
     expect(detectModelFamily("xai/grok-4-fast")).toBe("xai");
   });
 
+  test("direct grok → xai", () => {
+    expect(detectModelFamily("grok/grok-4-fast")).toBe("xai");
+  });
+
   test("direct deepseek → deepseek", () => {
     expect(detectModelFamily("deepseek/deepseek-chat")).toBe("deepseek");
   });


### PR DESCRIPTION
## Summary
- Adds a Codex-shaped **Grok (subscription)** provider (`grok/*`) using xAI device-code OAuth so SuperGrok / X Premium+ users can chat without an xAI console API path or a separate progrok process.
- Session file lives at `configDir()/xai-oauth.json` (mode `0600`) with refresh-before-expiry; `/grok login|status|logout|switch` mirrors Codex commands.
- Keeps the paid **Grok** console provider (`xai/*`) unchanged.
- Fixes model-picker visibility for `onRequestAuth` providers when logged out (Enter starts auth).
- Docs + unit tests included.

## Why
Users with SuperGrok want first-class login inside SoulForge/Empryo. The public tree had no subscription path; Empryo 3.4.5-beta appears to ship a partial **Grok Build** `/grok` surface that opens the model picker without a working OAuth session. This PR implements a full device-code flow on the public 2.20 line.

## Non-goals (v1)
- PKCE browser login
- Import from `~/.progrok/auth.json`
- VPN / Docker / progrok binary dependency
- Replacing or changing the `xai` console provider
- CLIProxyAPI changes

## Test plan
- [x] `bun test tests/grok-oauth.test.ts` (and related provider count tests)
- [x] `bun run typecheck`
- [x] Manual: isolated HOME login via `/grok login` and Ctrl+L → Grok (subscription)
- [x] Manual: chat turn after login; logout clears session
- [ ] CI green on this PR
- [ ] Maintainer note: may need merge with Empryo 3.x Grok Build stub when that source is aligned

## Notes for maintainers
- OAuth client id is the community id used by progrok/Hermes/OpenClaw lineage (documented + unofficial warning in docs).
- Portions of auth helpers adapted from progrok (MIT) — attributed in `THIRD_PARTY_LICENSES.md`.
- `openPath` now honors `$BROWSER` on Linux (helps isolated/dev profiles keep the user default browser).
