### PR TITLE
Refresh MiniMax provider to current M3/M2.7 parameters

### DIFF
--- a/mintlify-docs/providers/overview.mdx
+++ b/mintlify-docs/providers/overview.mdx
@@ -18,7 +18,7 @@ SoulForge ships 21 built-in providers. Set one key and go.
 | **DeepSeek** | `soulforge --set-key deepseek sk-...` | [platform.deepseek.com](https://platform.deepseek.com) |
 | **Mistral** | `soulforge --set-key mistral ...` | [console.mistral.ai](https://console.mistral.ai) |
 | **Fireworks** | `soulforge --set-key fireworks ...` | [fireworks.ai](https://fireworks.ai) |
-| **MiniMax** | `soulforge --set-key minimax ...` | [platform.minimaxi.com](https://platform.minimaxi.com) |
+| **MiniMax** | `soulforge --set-key minimax ...` | [platform.minimaxi.com](https://platform.minimaxi.com) · [platform.minimax.io](https://platform.minimax.io) |
 
 ## Gateways (one key, many models)
 

--- a/src/core/llm/compat-reasoning.ts
+++ b/src/core/llm/compat-reasoning.ts
@@ -21,7 +21,6 @@ const COMPAT_PROVIDERS = new Set([
   "deepseek",
   "groq",
   "fireworks",
-  "minimax",
   "copilot",
   "github-models",
   "opencode-go",

--- a/src/core/llm/provider-options.ts
+++ b/src/core/llm/provider-options.ts
@@ -331,8 +331,7 @@ function getModelCapabilities(modelId: string): ModelCapabilities {
       /glm-(4\.[5-9]|[5-9])/.test(base) ||
       /kimi-(k2|thinking)/.test(base) ||
       /gpt-oss/.test(base) ||
-      /deepseek-r1/.test(base) ||
-      /minimax-m[2-9]/.test(base);
+      /deepseek-r1/.test(base);
     return {
       ...BASE,
       compatReasoning: isCompatReasoning,

--- a/src/core/llm/providers/minimax.ts
+++ b/src/core/llm/providers/minimax.ts
@@ -1,9 +1,22 @@
-import { createMinimax } from "vercel-minimax-ai-provider";
-import { loadConfig } from "../../../config/index.js";
+import { createAnthropic } from "@ai-sdk/anthropic";
 import { getProviderApiKey } from "../../secrets.js";
-import { getCompatReasoningBody } from "../compat-reasoning.js";
-import { createSessionFetchWrapper } from "./reasoning-fetch.js";
+import { withSessionHeaders } from "./reasoning-fetch.js";
 import type { ProviderDefinition, ProviderModelInfo } from "./types.js";
+
+// Regional Anthropic-compatible endpoints for MiniMax.
+// global_en: https://platform.minimax.io — international account keys.
+// cn_zh:     https://platform.minimaxi.com — China account keys.
+// An account's key only validates against its own region, so the active
+// region is resolved at createModel time (global_en default, cn_zh via env).
+const ANTHROPIC_BASE_URLS: Record<string, string> = {
+  global_en: "https://api.minimax.io/anthropic",
+  cn_zh: "https://api.minimaxi.com/anthropic",
+};
+
+function resolveMinimaxBaseURL(): string {
+  const region = (process.env.MINIMAX_REGION ?? "global_en").toLowerCase();
+  return ANTHROPIC_BASE_URLS[region] ?? ANTHROPIC_BASE_URLS.global_en ?? "";
+}
 
 export const minimax: ProviderDefinition = {
   id: "minimax",
@@ -20,11 +33,13 @@ export const minimax: ProviderDefinition = {
     if (!apiKey) {
       throw new Error("MINIMAX_API_KEY is not set");
     }
-    const reasoningBody = getCompatReasoningBody(`minimax/${modelId}`, loadConfig());
-    const reasoningFetch = createSessionFetchWrapper(reasoningBody);
-    return createMinimax({
+    // Route through the Anthropic-compatible MiniMax endpoint with an explicit
+    // regional base URL (global_en default, cn_zh via MINIMAX_REGION) and the
+    // session-header fetch wrapper for cache-affinity routing.
+    return createAnthropic({
       apiKey,
-      ...(reasoningFetch ? { fetch: reasoningFetch as typeof fetch } : {}),
+      baseURL: resolveMinimaxBaseURL(),
+      fetch: withSessionHeaders() as typeof fetch,
     })(modelId);
   },
 
@@ -35,26 +50,16 @@ export const minimax: ProviderDefinition = {
 
   fallbackModels: [
     { id: "MiniMax-M3", name: "MiniMax M3" },
-    { id: "MiniMax-M3-highspeed", name: "MiniMax M3 HighSpeed" },
     { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
-    { id: "MiniMax-M2.7-highspeed", name: "MiniMax M2.7 HighSpeed" },
-    { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
-    { id: "MiniMax-M2.5-highspeed", name: "MiniMax M2.5 HighSpeed" },
-    { id: "MiniMax-M2.1", name: "MiniMax M2.1" },
-    { id: "MiniMax-M2.1-highspeed", name: "MiniMax M2.1 Lightning" },
-    { id: "MiniMax-M2", name: "MiniMax M2" },
   ],
 
   // from https://platform.minimax.io/docs/api-reference/text-openai-api#supported-models
+  // M3 = 1M context, adaptive/disabled thinking; M2.7 = 204.8k, always-on thinking.
   contextWindows: [
     ["MiniMax-M3", 1_000_000],
-    ["MiniMax-M3-highspeed", 1_000_000],
     ["MiniMax-M2.7", 204_800],
-    ["MiniMax-M2.7-highspeed", 204_800],
     ["MiniMax-M2.5", 204_800],
-    ["MiniMax-M2.5-highspeed", 204_800],
     ["MiniMax-M2.1", 204_800],
-    ["MiniMax-M2.1-highspeed", 204_800],
     ["MiniMax-M2", 204_800],
   ],
 };

--- a/src/stores/statusbar.ts
+++ b/src/stores/statusbar.ts
@@ -141,6 +141,12 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
   ministral: { input: 0.1, cacheWrite: 0.1, cacheRead: 0.01, output: 0.1 },
   pixtral: { input: 0.15, cacheWrite: 0.15, cacheRead: 0.015, output: 0.15 },
   devstral: { input: 0.1, cacheWrite: 0.1, cacheRead: 0.01, output: 0.3 },
+
+  // ── MiniMax ──────────────────────────────────────────────────────────
+  // Source: https://platform.minimax.io/docs/api-reference/text-openai-api (2026-07)
+  // cacheRead = 20% of input; M3 cache-write is not billed (null → 0).
+  "minimax-m3": { input: 0.6, cacheWrite: 0, cacheRead: 0.12, output: 2.4 },
+  "minimax-m2.7": { input: 0.3, cacheWrite: 0.375, cacheRead: 0.06, output: 1.2 },
 };
 
 const FREE_PRICING: ModelPricing = { input: 0, cacheWrite: 0, cacheRead: 0, output: 0 };
@@ -298,6 +304,9 @@ function matchPricing(modelId: string): ModelPricing {
   if (id.includes("grok")) return MODEL_PRICING["grok-4.3"] ?? DEFAULT_PRICING;
   if (id.includes("gpt")) return MODEL_PRICING["gpt-5.4"] ?? DEFAULT_PRICING;
   if (id.includes("deepseek")) return MODEL_PRICING["deepseek-chat"] ?? DEFAULT_PRICING;
+  if (id.includes("minimax-m3")) return MODEL_PRICING["minimax-m3"] ?? DEFAULT_PRICING;
+  if (id.includes("minimax-m2.7")) return MODEL_PRICING["minimax-m2.7"] ?? DEFAULT_PRICING;
+  if (id.includes("minimax")) return MODEL_PRICING["minimax-m2.7"] ?? DEFAULT_PRICING;
   return DEFAULT_PRICING;
 }
 

--- a/tests/minimax.test.ts
+++ b/tests/minimax.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { computeModelCost } from "../src/stores/statusbar.js";
+import { minimax } from "../src/core/llm/providers/minimax.js";
+import { getCompatReasoningBody } from "../src/core/llm/compat-reasoning.js";
+import type { AppConfig } from "../src/types/index.js";
+
+function baseConfig(perf: Partial<AppConfig["performance"]> = {}): AppConfig {
+  return {
+    defaultModel: "",
+    routerRules: [],
+    editor: { command: "nvim", args: [] },
+    theme: { name: "default" },
+    performance: perf,
+  } as unknown as AppConfig;
+}
+
+describe("MiniMax", () => {
+  test("registers M3 and M2.7 as fallback models", () => {
+    const ids = minimax.fallbackModels.map((m) => m.id);
+    expect(ids).toContain("MiniMax-M3");
+    expect(ids).toContain("MiniMax-M2.7");
+  });
+
+  test("declares M3 1M and M2.7 204.8k context windows", () => {
+    const ctx = Object.fromEntries(minimax.contextWindows);
+    expect(ctx["MiniMax-M3"]).toBe(1_000_000);
+    expect(ctx["MiniMax-M2.7"]).toBe(204_800);
+  });
+
+  test("MiniMax is no longer a compat reasoning_effort body injector", () => {
+    // After routing MiniMax through the Anthropic-compatible endpoint, the
+    // OpenAI-compat reasoning_effort body must not be injected — it would
+    // conflict with the Anthropic-shape thinking options.
+    const cfg = baseConfig({ effort: "high" });
+    expect(getCompatReasoningBody("minimax/MiniMax-M3", cfg)).toEqual({});
+    expect(getCompatReasoningBody("minimax/MiniMax-M2.7", cfg)).toEqual({});
+  });
+
+  test("M3 cost = $0.6 in + $2.4 out per 1M", () => {
+    const usage = { input: 1_000_000, output: 1_000_000, cacheRead: 0, cacheWrite: 0 };
+    expect(computeModelCost("minimax/MiniMax-M3", usage)).toBeCloseTo(0.6 + 2.4, 4);
+  });
+
+  test("M2.7 cost = $0.3 in + $1.2 out per 1M", () => {
+    const usage = { input: 1_000_000, output: 1_000_000, cacheRead: 0, cacheWrite: 0 };
+    expect(computeModelCost("minimax/MiniMax-M2.7", usage)).toBeCloseTo(0.3 + 1.2, 4);
+  });
+
+  test("M3 cache read billed at 20% of input", () => {
+    const cache = { input: 0, output: 0, cacheRead: 1_000_000, cacheWrite: 0 };
+    expect(computeModelCost("minimax/MiniMax-M3", cache)).toBeCloseTo(0.12, 4);
+  });
+});


### PR DESCRIPTION
Reason: Refresh the MiniMax provider to current M3 / M2.7 parameters (regional endpoints, context windows, pricing, thinking behavior).

## Changes

- **Regional endpoints**: Route MiniMax through the Anthropic-compatible endpoint (`@ai-sdk/anthropic` with an explicit `baseURL`) instead of the default `vercel-minimax-ai-provider` factory, and resolve the base URL per region — `global_en` (`https://api.minimax.io/anthropic`, default) and `cn_zh` (`https://api.minimaxi.com/anthropic` via `MINIMAX_REGION`). An account key only validates against its own region, so the region must be selectable.
- **Model list**: Trim `fallbackModels` to the current `MiniMax-M3` and `MiniMax-M2.7` SKUs.
- **Context windows**: Declare `MiniMax-M3` = 1,000,000 and `MiniMax-M2.7` = 204,800 (retaining the 204.8k value for the M2.x family).
- **Thinking behavior**: Remove MiniMax from the OpenAI-compatible `reasoning_effort` body injection (`COMPAT_PROVIDERS` and the `minimax-m[2-9]` compat-reasoning capability). Thinking now flows through Anthropic-shape options, matching M3 adaptive/disabled and M2.7 always-on behavior instead of a conflicting `reasoning_effort` body.
- **Pricing**: Add per-million-token pricing for `MiniMax-M3` ($0.6 in / $2.4 out, cache read 20% of input) and `MiniMax-M2.7` ($0.3 in / $1.2 out), with fallback heuristics in `matchPricing`.
- **Docs**: Link both the CN and global key portals in the providers overview.

## Checks

- `bun test tests/minimax.test.ts tests/provider-options.test.ts tests/new-providers.test.ts` — 106 pass.
- `tsc --noEmit` — clean.
- `biome check src/` — clean.
